### PR TITLE
Enable setting configuration key 'allow.auto.create.topics'

### DIFF
--- a/src/Dafda.Tests/Configuration/TestConfigurationKey.cs
+++ b/src/Dafda.Tests/Configuration/TestConfigurationKey.cs
@@ -34,6 +34,7 @@ namespace Dafda.Tests.Configuration
             {
                 ConfigurationKey.GroupId,
                 ConfigurationKey.EnableAutoCommit,
+                ConfigurationKey.AllowAutoCreateTopics,
                 ConfigurationKey.BootstrapServers,
                 ConfigurationKey.BrokerVersionFallback,
                 ConfigurationKey.ApiVersionFallbackMs,

--- a/src/Dafda.Tests/Configuration/TestConsumerConfigurationBuilder.cs
+++ b/src/Dafda.Tests/Configuration/TestConsumerConfigurationBuilder.cs
@@ -43,6 +43,7 @@ namespace Dafda.Tests.Configuration
                 .WithConfigurationSource(new ConfigurationSourceStub(
                     (key: "DEFAULT_KAFKA_GROUP_ID", value: "default_foo"),
                     (key: "SAMPLE_KAFKA_ENABLE_AUTO_COMMIT", value: "true"),
+                    (key: "SAMPLE_KAFKA_ALLOW_AUTO_CREATE_TOPICS", value: "false"),
                     (key: ConfigurationKey.GroupId, value: "foo"),
                     (key: ConfigurationKey.BootstrapServers, value: "bar"),
                     (key: "dummy", value: "ignored")
@@ -56,6 +57,7 @@ namespace Dafda.Tests.Configuration
             AssertKeyValue(configuration, ConfigurationKey.GroupId, "baz");
             AssertKeyValue(configuration, ConfigurationKey.BootstrapServers, "bar");
             AssertKeyValue(configuration, ConfigurationKey.EnableAutoCommit, "true");
+            AssertKeyValue(configuration, ConfigurationKey.AllowAutoCreateTopics, "false");
             AssertKeyValue(configuration, "dummy", null);
         }
 

--- a/src/Dafda/Configuration/ConfigurationKey.cs
+++ b/src/Dafda/Configuration/ConfigurationKey.cs
@@ -8,6 +8,7 @@ namespace Dafda.Configuration
     {
         public static readonly ConfigurationKey GroupId = new ConfigurationKey("group.id", ConfigurationKeyGroup.ConsumerOnly);
         public static readonly ConfigurationKey EnableAutoCommit = new ConfigurationKey("enable.auto.commit", ConfigurationKeyGroup.ConsumerOnly);
+        public static readonly ConfigurationKey AllowAutoCreateTopics = new ConfigurationKey("allow.auto.create.topics", ConfigurationKeyGroup.ConsumerOnly);
         public static readonly ConfigurationKey BootstrapServers = new ConfigurationKey("bootstrap.servers");
         public static readonly ConfigurationKey BrokerVersionFallback = new ConfigurationKey("broker.version.fallback");
         public static readonly ConfigurationKey ApiVersionFallbackMs = new ConfigurationKey("api.version.fallback.ms");

--- a/src/Dafda/Configuration/ConsumerConfigurationBuilder.cs
+++ b/src/Dafda/Configuration/ConsumerConfigurationBuilder.cs
@@ -12,6 +12,7 @@ namespace Dafda.Configuration
         {
             ConfigurationKey.GroupId,
             ConfigurationKey.EnableAutoCommit,
+            ConfigurationKey.AllowAutoCreateTopics,
             ConfigurationKey.BootstrapServers,
             ConfigurationKey.BrokerVersionFallback,
             ConfigurationKey.ApiVersionFallbackMs,


### PR DESCRIPTION
Enable setting configuration key [allow.auto.create.topics](http://kafka.apache.org/documentation.html#allow.auto.create.topics) through environment variable.

**Reasoning**
From version 1.5.0 of librdkafka, the consumer will no longer trigger auto creation of topics. It is still supported by setting `allow.auto.create.topics = true`. Being able to auto-create topics is very useful for local development (but should not be used for production).
Release note with information about the change is available here: [librdkafka v1.5.0](https://github.com/edenhill/librdkafka/releases/tag/v1.5.0) - see 'Upgrade considerations'.