### PR TITLE
Upgrade Confluent.Kafka to version 1.5.3

### DIFF
--- a/src/Dafda/Dafda.csproj
+++ b/src/Dafda/Dafda.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.4.4" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.3" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
 


### PR DESCRIPTION
- Relates to PR #15 as the `allow.auto.create.topics` setting is supported from librdkafka 1.5.0.
- Includes newest features and improvements from the Confluent.Kafka package.