### PR TITLE
Expose metadata properties

### DIFF
--- a/src/Dafda/Consuming/MessageHandlerContext.cs
+++ b/src/Dafda/Consuming/MessageHandlerContext.cs
@@ -35,6 +35,16 @@ namespace Dafda.Consuming
         public virtual string MessageType => _metadata.Type;
 
         /// <summary>
+        /// The message correlation identifier.
+        /// </summary>
+        public virtual string CorrelationId => _metadata.CorrelationId;
+
+        /// <summary>
+        /// The message causation identifier.
+        /// </summary>
+        public virtual string CausationId => _metadata.CausationId;
+
+        /// <summary>
         /// Access to message metadata values.
         /// </summary>
         /// <param name="key">A metadata name</param>


### PR DESCRIPTION
Ensure that we on the messagehandler can access default metadata properties such as CorrelationId and CausationId
#33 
