### PR TITLE
Make it possible to produce a message together with a metadata object

### DIFF
--- a/src/Dafda.Tests/Builders/PayloadDescriptorBuilder.cs
+++ b/src/Dafda.Tests/Builders/PayloadDescriptorBuilder.cs
@@ -12,7 +12,7 @@ namespace Dafda.Tests.Builders
         private string _partitionKey;
         private string _messageType;
         private object _messageData;
-        private IEnumerable<KeyValuePair<string, object>> _messageHeaders;
+        private IEnumerable<KeyValuePair<string, string>> _messageHeaders;
 
         public PayloadDescriptorBuilder()
         {
@@ -21,7 +21,7 @@ namespace Dafda.Tests.Builders
             _partitionKey = "dummy-partition-key";
             _messageType = "dummy-message-type";
             _messageData = "dummy-message-data";
-            _messageHeaders = Enumerable.Empty<KeyValuePair<string, object>>();
+            _messageHeaders = Enumerable.Empty<KeyValuePair<string, string>>();
         }
 
         public PayloadDescriptorBuilder WithMessageId(string messageId)
@@ -54,7 +54,7 @@ namespace Dafda.Tests.Builders
             return this;
         }
 
-        public PayloadDescriptorBuilder WithMessageHeaders(params KeyValuePair<string, object>[] messageHeaders)
+        public PayloadDescriptorBuilder WithMessageHeaders(params KeyValuePair<string, string>[] messageHeaders)
         {
             _messageHeaders = messageHeaders;
             return this;

--- a/src/Dafda.Tests/Producing/TestDefaultPayloadSerializer.cs
+++ b/src/Dafda.Tests/Producing/TestDefaultPayloadSerializer.cs
@@ -63,7 +63,7 @@ namespace Dafda.Tests.Producing
             var sut = new DefaultPayloadSerializer();
 
             var messageDataStub = "foo-message-data";
-            var headerEntryStub = KeyValuePair.Create<string, object>("foo", "bar");
+            var headerEntryStub = KeyValuePair.Create("foo", "bar");
 
             var payloadStub = new PayloadDescriptorBuilder()
                 .WithMessageData(messageDataStub)

--- a/src/Dafda.v3.ncrunchsolution
+++ b/src/Dafda.v3.ncrunchsolution
@@ -1,0 +1,5 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/src/Dafda.v3.ncrunchsolution
+++ b/src/Dafda.v3.ncrunchsolution
@@ -1,5 +1,0 @@
-﻿<SolutionConfiguration>
-  <Settings>
-    <SolutionConfigured>True</SolutionConfigured>
-  </Settings>
-</SolutionConfiguration>

--- a/src/Dafda/Consuming/Metadata.cs
+++ b/src/Dafda/Consuming/Metadata.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Dafda.Consuming
 {
@@ -75,6 +76,15 @@ namespace Dafda.Consuming
                 return value;
             }
             private set => _metadata[key] = value;
+        }
+
+        /// <summary>
+        /// Creates an enumerable of headers
+        /// </summary>
+        /// <returns>Headers</returns>
+        public IEnumerable<KeyValuePair<string, string>> AsEnumerable()
+        {
+            return _metadata.AsEnumerable();
         }
     }
 }

--- a/src/Dafda/Outbox/OutboxQueue.cs
+++ b/src/Dafda/Outbox/OutboxQueue.cs
@@ -53,7 +53,7 @@ namespace Dafda.Outbox
 
         private async Task<OutboxEntry> CreateOutboxEntry(object message)
         {
-            var payloadDescriptor = _payloadDescriptorFactory.Create(message, new Dictionary<string, object>());
+            var payloadDescriptor = _payloadDescriptorFactory.Create(message, new Dictionary<string, string>());
 
             var messageId = Guid.Parse(payloadDescriptor.MessageId);
 

--- a/src/Dafda/Producing/PayloadDescriptorFactory.cs
+++ b/src/Dafda/Producing/PayloadDescriptorFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Dafda.Consuming;
 using Dafda.Serializing;
 
 namespace Dafda.Producing
@@ -15,7 +16,7 @@ namespace Dafda.Producing
             _messageIdGenerator = messageIdGenerator;
         }
 
-        public PayloadDescriptor Create(object message, Dictionary<string, object> headers)
+        public PayloadDescriptor Create(object message, Metadata headers)
         {
             var registration = _outgoingMessageRegistry.GetRegistration(message);
             if (registration == null)
@@ -29,8 +30,14 @@ namespace Dafda.Producing
                 partitionKey: registration.KeySelector(message),
                 messageType: registration.Type,
                 messageData: message,
-                messageHeaders: headers
+                messageHeaders: headers.AsEnumerable()
             );
+        }
+
+
+        public PayloadDescriptor Create(object message, Dictionary<string, string> headers)
+        {
+            return Create(message, new Metadata(headers));
         }
     }
 }

--- a/src/Dafda/Producing/Producer.cs
+++ b/src/Dafda/Producing/Producer.cs
@@ -1,5 +1,7 @@
 ﻿using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Linq;
+using Dafda.Consuming;
 
 namespace Dafda.Producing
 {
@@ -29,14 +31,27 @@ namespace Dafda.Producing
         }
 
         /// <summary>
+        /// Produce a <paramref name="message"/> on Kafka
+        /// </summary>
+        /// <param name="message">The message</param>
+        /// <param name="headers">The message headers</param>
+        public async Task Produce(object message, Metadata headers)
+        {
+            var payloadDescriptor = _payloadDescriptorFactory.Create(message, headers);
+            await _kafkaProducer.Produce(payloadDescriptor);
+        }
+
+
+
+        /// <summary>
         /// Produce a <paramref name="message"/> on Kafka including <paramref name="headers"/>
         /// </summary>
         /// <param name="message">The message</param>
         /// <param name="headers">The message headers</param>
         public async Task Produce(object message, Dictionary<string, object> headers)
         {
-            var payloadDescriptor = _payloadDescriptorFactory.Create(message, headers);
-            await _kafkaProducer.Produce(payloadDescriptor);
+            var dict = headers.ToDictionary( pair => pair.Key, pair => pair.Value.ToString());
+            await Produce(message, new Metadata( dict ));
         }
     }
 }

--- a/src/Dafda/Serializing/PayloadDescriptor.cs
+++ b/src/Dafda/Serializing/PayloadDescriptor.cs
@@ -18,7 +18,7 @@ namespace Dafda.Serializing
         /// <param name="messageType">The message type</param>
         /// <param name="messageData">The message</param>
         /// <param name="messageHeaders">A list of headers</param>
-        public PayloadDescriptor(string messageId, string topicName, string partitionKey, string messageType, object messageData, IEnumerable<KeyValuePair<string, object>> messageHeaders)
+        public PayloadDescriptor(string messageId, string topicName, string partitionKey, string messageType, object messageData, IEnumerable<KeyValuePair<string, string>> messageHeaders)
         {
             MessageId = messageId;
             TopicName = topicName;
@@ -51,7 +51,7 @@ namespace Dafda.Serializing
         /// <summary>
         /// The list of headers
         /// </summary>
-        public IEnumerable<KeyValuePair<string, object>> MessageHeaders { get; private set; }
+        public IEnumerable<KeyValuePair<string, string>> MessageHeaders { get; private set; }
 
         /// <summary>
         /// The message


### PR DESCRIPTION
When producing a metadata object it is easier to see if we have filled in the right headers and given them the right name

#35 