### PR TITLE
Ensure topics have a value, so we don't get an AccessViolationException.

### DIFF
--- a/src/Dafda.Tests/Consuming/TestMessageRegistration.cs
+++ b/src/Dafda.Tests/Consuming/TestMessageRegistration.cs
@@ -49,6 +49,15 @@ namespace Dafda.Tests.Consuming
         }
 
         [Fact]
+        public void throws_for_null_topic()
+        {
+            Assert.Throws<ArgumentException>(() => 
+                new MessageRegistrationBuilder()
+                .WithTopic(null)
+                .Build());
+        }
+
+        [Fact]
         public void returns_expected_message_type()
         {
             var expectedMessageType = "foo";

--- a/src/Dafda/Consuming/MessageRegistration.cs
+++ b/src/Dafda/Consuming/MessageRegistration.cs
@@ -28,7 +28,7 @@ namespace Dafda.Consuming
         private static string EnsureValidTopicName(string topicName)
         {
             // Passing a null topic, will cause Confluent to throw an AccessViolationException, which cannot be caught by the service, resulting in a hard crash without logs.
-            if (string.IsNullOrWhiteSpace(topicName))
+            if (topicName == null)
             {
                 throw new ArgumentException(nameof(topicName), "Topic must have a value");
             }

--- a/src/Dafda/Consuming/MessageRegistration.cs
+++ b/src/Dafda/Consuming/MessageRegistration.cs
@@ -21,8 +21,19 @@ namespace Dafda.Consuming
 
             HandlerInstanceType = handlerInstanceType;
             MessageInstanceType = messageInstanceType;
-            Topic = topic;
             MessageType = messageType;
+            Topic = EnsureValidTopicName(topic);
+        }
+
+        private static string EnsureValidTopicName(string topicName)
+        {
+            // Passing a null topic, will cause Confluent to throw an AccessViolationException, which cannot be caught by the service, resulting in a hard crash without logs.
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException(nameof(topicName), "Topic must have a value");
+            }
+
+            return topicName;
         }
 
         private static void EnsureProperHandlerType(Type handlerInstanceType, Type messageInstanceType)


### PR DESCRIPTION
Added check for null/empty string on MessageRegistration.