### PR TITLE
Remove generic constraints on IMessageHandler interface

### DIFF
--- a/src/Dafda.Tests/Consuming/TestJsonIncomingMessageFactory.cs
+++ b/src/Dafda.Tests/Consuming/TestJsonIncomingMessageFactory.cs
@@ -63,18 +63,7 @@ namespace Dafda.Tests.Consuming
             Assert.Equal(2, data.Position.Longitude);
         }
 
-        public class VehiclePositionChanged
-        {
-            public string AggregateId { get; set; }
-            public string VehicleId { get; set; }
-            public DateTime TimeStamp { get; set; }
-            public Position Position { get; set; }
-        }
-
-        public class Position
-        {
-            public double Latitude { get; set; }
-            public double Longitude { get; set; }
-        }
+        public record VehiclePositionChanged(string AggregateId, string VehicleId, DateTime TimeStamp, Position Position);
+        public record Position(double Latitude, double Longitude);
     }
 }

--- a/src/Dafda.Tests/IsExternalInit.cs
+++ b/src/Dafda.Tests/IsExternalInit.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel;
+
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// This is a fix for non .net 5 versions. Enables us to use init methods on properties
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}

--- a/src/Dafda/Consuming/IMessageHandler.cs
+++ b/src/Dafda/Consuming/IMessageHandler.cs
@@ -7,7 +7,7 @@ namespace Dafda.Consuming
     /// will allow Dafda to redirect consumed messages to the concrete message handler implementation. 
     /// </summary>
     /// <typeparam name="T">The message type</typeparam>
-    public interface IMessageHandler<T> where T : class, new()
+    public interface IMessageHandler<T>
     {
         /// <summary>
         /// Consumed message of <typeparamref name="T"/> are passed to the concrete


### PR DESCRIPTION
Requiring class, new() means that c# record types can't be used for the message
type, which sucks because records are very good for holding data which is what
messages do.

In order to get the tests to build I had to add the IsExternalInit method -
which afaik shouldn't be required for .net5 so it's very confusing, but this
should be ok because it's just the test project so it won't be referenced by
anything else.

This would probably have an impact on #17 ;)