### PR TITLE
Implemented message filters for headers in dafda library

### DIFF
--- a/src/Dafda.Tests/Builders/ConsumerBuilder.cs
+++ b/src/Dafda.Tests/Builders/ConsumerBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Dafda.Consuming;
+using Dafda.Consuming.MessageFilters;
 using Dafda.Tests.TestDoubles;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -14,6 +15,7 @@ namespace Dafda.Tests.Builders
         private IUnconfiguredMessageHandlingStrategy _unconfiguredMessageStrategy;
 
         private bool _enableAutoCommit;
+        private MessageFilter _messageFilter = MessageFilter.Default;
 
         public ConsumerBuilder()
         {
@@ -57,6 +59,11 @@ namespace Dafda.Tests.Builders
             return this;
         }
 
+        public void WithMessageFilter(MessageFilter messageFilter)
+        {
+            _messageFilter = messageFilter;
+        }
+
         public ConsumerBuilder WithUnconfiguredMessageStrategy(
             IUnconfiguredMessageHandlingStrategy strategy)
         {
@@ -70,6 +77,7 @@ namespace Dafda.Tests.Builders
                 _unitOfWorkFactory,
                 _consumerScopeFactory(NullLoggerFactory.Instance),
                 _unconfiguredMessageStrategy,
+                _messageFilter,
                 _enableAutoCommit);
     }
 }

--- a/src/Dafda/Configuration/ConsumerConfiguration.cs
+++ b/src/Dafda/Configuration/ConsumerConfiguration.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Dafda.Consuming;
+using Dafda.Consuming.MessageFilters;
 using Microsoft.Extensions.Logging;
 
 namespace Dafda.Configuration
@@ -8,12 +9,13 @@ namespace Dafda.Configuration
     internal class ConsumerConfiguration
     {
         public ConsumerConfiguration(IDictionary<string, string> configuration, MessageHandlerRegistry messageHandlerRegistry, 
-            IHandlerUnitOfWorkFactory unitOfWorkFactory, Func<ILoggerFactory, IConsumerScopeFactory> consumerScopeFactory)
+            IHandlerUnitOfWorkFactory unitOfWorkFactory, Func<ILoggerFactory, IConsumerScopeFactory> consumerScopeFactory, MessageFilter messageFilter)
         {
             KafkaConfiguration = configuration;
             MessageHandlerRegistry = messageHandlerRegistry;
             UnitOfWorkFactory = unitOfWorkFactory;
             ConsumerScopeFactory = consumerScopeFactory;
+            MessageFilter = messageFilter;
         }
 
         public IDictionary<string, string> KafkaConfiguration { get; }
@@ -22,6 +24,8 @@ namespace Dafda.Configuration
         public Func<ILoggerFactory, IConsumerScopeFactory> ConsumerScopeFactory { get; }
 
         public string GroupId => KafkaConfiguration[ConfigurationKey.GroupId];
+
+        public MessageFilter MessageFilter { get; }
 
         public bool EnableAutoCommit
         {

--- a/src/Dafda/Configuration/ConsumerConfigurationBuilder.cs
+++ b/src/Dafda/Configuration/ConsumerConfigurationBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Dafda.Consuming;
+using Dafda.Consuming.MessageFilters;
 using Microsoft.Extensions.Logging;
 
 namespace Dafda.Configuration
@@ -38,6 +39,8 @@ namespace Dafda.Configuration
         private Func<ILoggerFactory, IConsumerScopeFactory> _consumerScopeFactory;
         private IIncomingMessageFactory _incomingMessageFactory = new JsonIncomingMessageFactory();
         private bool _readFromBeginning;
+
+        private MessageFilter _messageFilter = MessageFilter.Default;
 
         public ConsumerConfigurationBuilder WithConfigurationSource(ConfigurationSource configurationSource)
         {
@@ -103,6 +106,10 @@ namespace Dafda.Configuration
             return this;
         }
 
+        public void WithMessageFilter(MessageFilter messageFilter)
+        {
+            _messageFilter = messageFilter;
+        }
 
         public ConsumerConfigurationBuilder RegisterMessageHandler<TMessage, TMessageHandler>(string topic, string messageType)
             where TMessageHandler : IMessageHandler<TMessage>
@@ -148,7 +155,8 @@ namespace Dafda.Configuration
                 configuration: configurations,
                 messageHandlerRegistry: _messageHandlerRegistry,
                 unitOfWorkFactory: _unitOfWorkFactory,
-                consumerScopeFactory: _consumerScopeFactory
+                consumerScopeFactory: _consumerScopeFactory,
+                messageFilter: _messageFilter
             );
         }
     }

--- a/src/Dafda/Configuration/ConsumerOptions.cs
+++ b/src/Dafda/Configuration/ConsumerOptions.cs
@@ -136,8 +136,12 @@ namespace Dafda.Configuration
         }
 
         /// <summary>
-        /// Filter to be applied on the consumption of each event.
+        /// Applies a filter that must be evaluated when consumer events.
+        /// If the filter evaluated returns false, the event will not be sent to the registered EventHandler class.
+        /// If the filter evaluated returns true, the event will be sent to the registered EventHandler.
+        /// In either case, the commit logic will continue and the index will be updated.
         /// </summary>
+        /// <param name="messageFilter">Overridable message filter exposing CanAcceptMessage evaluation.></param>
         public void WithMessageFilter(MessageFilter messageFilter)
         {
             _builder.WithMessageFilter(messageFilter);

--- a/src/Dafda/Configuration/ConsumerOptions.cs
+++ b/src/Dafda/Configuration/ConsumerOptions.cs
@@ -136,7 +136,7 @@ namespace Dafda.Configuration
         }
 
         /// <summary>
-        /// Applies a filter that must be evaluated when consumer events.
+        /// Applies a filter that must be evaluated when consuming events.
         /// If the filter evaluated returns false, the event will not be sent to the registered EventHandler class.
         /// If the filter evaluated returns true, the event will be sent to the registered EventHandler.
         /// In either case, the commit logic will continue and the index will be updated.

--- a/src/Dafda/Configuration/ConsumerOptions.cs
+++ b/src/Dafda/Configuration/ConsumerOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using Dafda.Consuming;
+using Dafda.Consuming.MessageFilters;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -132,6 +133,14 @@ namespace Dafda.Configuration
         public void WithIncomingMessageFactory(IIncomingMessageFactory incomingMessageFactory)
         {
             _builder.WithIncomingMessageFactory(incomingMessageFactory);
+        }
+
+        /// <summary>
+        /// Filter to be applied on the consumption of each event.
+        /// </summary>
+        public void WithMessageFilter(MessageFilter messageFilter)
+        {
+            _builder.WithMessageFilter(messageFilter);
         }
 
         /// <summary>

--- a/src/Dafda/Configuration/ConsumerServiceCollectionExtensions.cs
+++ b/src/Dafda/Configuration/ConsumerServiceCollectionExtensions.cs
@@ -69,6 +69,7 @@ namespace Dafda.Configuration
                     provider.GetRequiredService<IHandlerUnitOfWorkFactory>(),
                     configuration.ConsumerScopeFactory(provider.GetRequiredService<ILoggerFactory>()),
                     provider.GetRequiredService<IUnconfiguredMessageHandlingStrategy>(),
+                    configuration.MessageFilter,
                     configuration.EnableAutoCommit
                 ),
                 configuration.GroupId

--- a/src/Dafda/Consuming/Consumer.cs
+++ b/src/Dafda/Consuming/Consumer.cs
@@ -55,9 +55,7 @@ namespace Dafda.Consuming
         {
             var messageResult = await consumerScope.GetNext(cancellationToken);
 
-            var acceptMessage = _messageFilter.CanAcceptMessage(messageResult);
-
-            if(acceptMessage)
+            if(_messageFilter.CanAcceptMessage(messageResult))
             {
                 await _localMessageDispatcher.Dispatch(messageResult.Message);
             }

--- a/src/Dafda/Consuming/Consumer.cs
+++ b/src/Dafda/Consuming/Consumer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Dafda.Consuming.MessageFilters;
 
 namespace Dafda.Consuming
 {
@@ -8,6 +9,7 @@ namespace Dafda.Consuming
     {
         private readonly LocalMessageDispatcher _localMessageDispatcher;
         private readonly IConsumerScopeFactory _consumerScopeFactory;
+        private readonly MessageFilter _messageFilter;
         private readonly bool _isAutoCommitEnabled;
 
         public Consumer(
@@ -15,6 +17,7 @@ namespace Dafda.Consuming
             IHandlerUnitOfWorkFactory unitOfWorkFactory,
             IConsumerScopeFactory consumerScopeFactory,
             IUnconfiguredMessageHandlingStrategy fallbackHandler,
+            MessageFilter messageFilter,
             bool isAutoCommitEnabled = false)
         {
             _localMessageDispatcher =
@@ -25,6 +28,7 @@ namespace Dafda.Consuming
             _consumerScopeFactory =
                 consumerScopeFactory
                 ?? throw new ArgumentNullException(nameof(consumerScopeFactory));
+            _messageFilter = messageFilter;
             _isAutoCommitEnabled = isAutoCommitEnabled;
         }
 
@@ -50,7 +54,13 @@ namespace Dafda.Consuming
         private async Task ProcessNextMessage(ConsumerScope consumerScope, CancellationToken cancellationToken)
         {
             var messageResult = await consumerScope.GetNext(cancellationToken);
-            await _localMessageDispatcher.Dispatch(messageResult.Message);
+
+            var acceptMessage = _messageFilter.CanAcceptMessage(messageResult);
+
+            if(acceptMessage)
+            {
+                await _localMessageDispatcher.Dispatch(messageResult.Message);
+            }
 
             if (!_isAutoCommitEnabled)
             {

--- a/src/Dafda/Consuming/MessageFilters/MessageFilter.cs
+++ b/src/Dafda/Consuming/MessageFilters/MessageFilter.cs
@@ -1,0 +1,28 @@
+﻿namespace Dafda.Consuming.MessageFilters
+{
+    /// <summary>
+    /// Filter for messaging prior to calling consumer.
+    /// Exposes Can Accept Message handler.
+    /// </summary>
+    public abstract class MessageFilter
+    {
+        /// <summary>
+        /// Default message filter if one is not specified.
+        /// </summary>
+        public static MessageFilter Default = new DefaultMessageFilter();
+
+        /// <summary>
+        /// Overridable Can Accept Message flag.
+        /// </summary>
+        public abstract bool CanAcceptMessage(MessageResult result);
+
+        private class DefaultMessageFilter : MessageFilter
+        {
+            public override bool CanAcceptMessage(MessageResult result)
+            {
+                // allow all messages to be processed
+                return true;
+            }
+        }
+    }
+}

--- a/src/Dafda/Consuming/MessageFilters/MultiHeaderMessageFilter.cs
+++ b/src/Dafda/Consuming/MessageFilters/MultiHeaderMessageFilter.cs
@@ -50,7 +50,7 @@ namespace Dafda.Consuming.MessageFilters
 
         private bool EvaluateKeyValuePair(Dictionary<string, string> headers, KeyValuePair<string, string> header)
         {
-            var targetHeader = headers.FirstOrDefault(x => x.Key.Equals(header.Key, StringComparison.CurrentCultureIgnoreCase));
+            var targetHeader = headers.FirstOrDefault(x => x.Key.Equals(header.Key, StringComparison.InvariantCultureIgnoreCase));
 
             if (targetHeader.Equals(default(KeyValuePair<string, string>)))
             {

--- a/src/Dafda/Consuming/MessageFilters/MultiHeaderMessageFilter.cs
+++ b/src/Dafda/Consuming/MessageFilters/MultiHeaderMessageFilter.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dafda.Configuration;
+using Dafda.Serializing;
+
+namespace Dafda.Consuming.MessageFilters
+{
+    /// <inheritdoc />
+    public class MultiHeaderMessageFilter : MessageFilter
+    {
+        private readonly Dictionary<string, string> _headers;
+        private readonly bool _matchAll;
+
+        /// <summary>
+        /// Evaluates target headers on consumed message to determine whether to disregard message.
+        /// </summary>
+        /// <param name="headers">Headers to filter on for message consumption.</param>
+        /// <param name="matchAll">Defaulted to false. False = Only one header and value need to match one in the message. True = All headers and values need to match those from the message.</param>
+        public MultiHeaderMessageFilter(Dictionary<string, string> headers, bool matchAll = false)
+        {
+            if (headers.Any(x => string.IsNullOrWhiteSpace(x.Key) || string.IsNullOrWhiteSpace(x.Value)))
+            {
+                throw new InvalidConfigurationException("All Headers and Values must not be null or empty");
+            }
+
+            _headers = headers;
+            _matchAll = matchAll;
+        }
+
+        /// <inheritdoc />
+        public override bool CanAcceptMessage(MessageResult result)
+        {
+            if (result?.Message != null)
+            {
+                var messageHeaders = result.Message.Metadata.AsEnumerable().ToDictionary(k => k.Key, v => v.Value);
+
+                if (_matchAll)
+                {
+                    return _headers.All(header => EvaluateKeyValuePair(messageHeaders, header));
+                }
+                else
+                {
+                    return _headers.Any(header => EvaluateKeyValuePair(messageHeaders, header));
+                }
+            }
+
+            return false;
+        }
+
+        private bool EvaluateKeyValuePair(Dictionary<string, string> headers, KeyValuePair<string, string> header)
+        {
+            var targetHeader = headers.FirstOrDefault(x => x.Key.Equals(header.Key, StringComparison.CurrentCultureIgnoreCase));
+
+            if (targetHeader.Equals(default(KeyValuePair<string, string>)))
+            {
+                return false;
+            }
+
+            return string.Equals(targetHeader.Value, header.Value, StringComparison.InvariantCultureIgnoreCase);
+        }
+    }
+}

--- a/src/Dafda/Consuming/MessageFilters/SingleHeaderMessageFilter.cs
+++ b/src/Dafda/Consuming/MessageFilters/SingleHeaderMessageFilter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Linq;
+using Dafda.Configuration;
+
+namespace Dafda.Consuming.MessageFilters
+{
+    /// <inheritdoc />
+    public class SingleHeaderMessageFilter : MessageFilter
+    {
+        private readonly string _referenceHeaderName;
+        private readonly string _requiredHeaderValue;
+
+        /// <inheritdoc />
+        public SingleHeaderMessageFilter(string headerName, string headerValue)
+        {
+            if (string.IsNullOrWhiteSpace(headerName))
+            {
+                throw new InvalidConfigurationException("HeaderName must not be null or empty in the HeaderMessageFilter");
+            }
+
+            if (string.IsNullOrWhiteSpace(headerValue))
+            {
+                throw new InvalidConfigurationException("HeaderValue must not be null or empty in the HeaderMessageFilter");
+            }
+
+            _referenceHeaderName = headerName;
+            _requiredHeaderValue = headerValue;
+        }
+
+        /// <inheritdoc />
+        public override bool CanAcceptMessage(MessageResult result)
+        {
+            if (result?.Message != null)
+            {
+               var header = result.Message.Metadata.AsEnumerable()?.FirstOrDefault(i => string.Equals(i.Key, _referenceHeaderName, StringComparison.InvariantCultureIgnoreCase));
+
+               if (header != null && header.HasValue && header.Value.Value != null && string.Equals(header.Value.Value, _requiredHeaderValue, StringComparison.InvariantCultureIgnoreCase))
+               {
+                   return true;
+               }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Dafda/Consuming/MessageFilters/SingleHeaderMessageFilter.cs
+++ b/src/Dafda/Consuming/MessageFilters/SingleHeaderMessageFilter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Collections.Generic;
 using Dafda.Configuration;
 
 namespace Dafda.Consuming.MessageFilters
@@ -30,14 +31,11 @@ namespace Dafda.Consuming.MessageFilters
         /// <inheritdoc />
         public override bool CanAcceptMessage(MessageResult result)
         {
-            if (result?.Message != null)
-            {
-               var header = result.Message.Metadata.AsEnumerable()?.FirstOrDefault(i => string.Equals(i.Key, _referenceHeaderName, StringComparison.InvariantCultureIgnoreCase));
+            var header = result?.Message.Metadata.AsEnumerable()?.FirstOrDefault(i => string.Equals(i.Key, _referenceHeaderName, StringComparison.InvariantCultureIgnoreCase));
 
-               if (header != null && header.HasValue && header.Value.Value != null && string.Equals(header.Value.Value, _requiredHeaderValue, StringComparison.InvariantCultureIgnoreCase))
-               {
-                   return true;
-               }
+            if (header.HasValue && header.Equals(default(KeyValuePair<string, string>)) && string.Equals(header.Value.Value, _requiredHeaderValue, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return true;
             }
 
             return false;

--- a/src/Dafda/Consuming/MessageResult.cs
+++ b/src/Dafda/Consuming/MessageResult.cs
@@ -4,7 +4,8 @@ using System.Threading.Tasks;
 namespace Dafda.Consuming
 {
     /// <summary>
-    /// Resulting Message contaning Transport Level Message
+    /// Object that contains message when consumed from Kafka.
+    /// To be used for message handling prior to dispatching to the handlers.
     /// </summary>
     public class MessageResult
     {
@@ -21,7 +22,7 @@ namespace Dafda.Consuming
         }
 
         /// <summary>
-        /// Transmitted message
+        /// Transmitted message consumed from Kafka
         /// </summary>
         public TransportLevelMessage Message { get; }
 

--- a/src/Dafda/Consuming/MessageResult.cs
+++ b/src/Dafda/Consuming/MessageResult.cs
@@ -3,19 +3,31 @@ using System.Threading.Tasks;
 
 namespace Dafda.Consuming
 {
-    internal sealed class MessageResult
+    /// <summary>
+    /// Resulting Message contaning Transport Level Message
+    /// </summary>
+    public class MessageResult
     {
         private static readonly Func<Task> EmptyCommitAction = () => Task.CompletedTask;
         private readonly Func<Task> _onCommit;
 
+        /// <summary>
+        /// Resulting Message contaning Transport Level Message
+        /// </summary>
         public MessageResult(TransportLevelMessage message, Func<Task> onCommit = null)
         {
             Message = message;
             _onCommit = onCommit ?? EmptyCommitAction;
         }
 
+        /// <summary>
+        /// Transmitted message
+        /// </summary>
         public TransportLevelMessage Message { get; }
 
+        /// <summary>
+        /// Commit message to handlers
+        /// </summary>
         public async Task Commit()
         {
             await _onCommit();


### PR DESCRIPTION
Implemented the ability to filter consumed messages prior to dispatching messages to handler classes.
Filter extension takes any class that inherits from MessageFilter so you can easily extend the possible filters.
For this implementation I have created the following filters:
- SingleHeaderMessageFilter which takes a header name and value that the event must contain to be accepted into handler.
- MultiHeaderMessageFilter which takes a Dictionary<string, string> of headers (headerName, headerValue) with an optional parameter of matchAll that is set to false by default.
- - If matchAll is false - only one header and value have to exist in the event headers to be a valid event for dispatching
- - If matchAll is true - all provided headers and values have to exist in the event headers to be a valid event for dispatching