### PR TITLE
Feature/poison

### DIFF
--- a/src/Dafda.Tests/Builders/ConsumerBuilder.cs
+++ b/src/Dafda.Tests/Builders/ConsumerBuilder.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using Dafda.Consuming;
+﻿using Dafda.Consuming;
 using Dafda.Consuming.MessageFilters;
 using Dafda.Tests.TestDoubles;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Dafda.Tests.Builders
 {
     internal class ConsumerBuilder
     {
         private IHandlerUnitOfWorkFactory _unitOfWorkFactory;
-        private Func<ILoggerFactory, IConsumerScopeFactory> _consumerScopeFactory;
+        private IConsumerScopeFactory _consumerScopeFactory;
         private MessageHandlerRegistry _registry;
         private IUnconfiguredMessageHandlingStrategy _unconfiguredMessageStrategy;
 
@@ -20,11 +17,7 @@ namespace Dafda.Tests.Builders
         public ConsumerBuilder()
         {
             _unitOfWorkFactory = new HandlerUnitOfWorkFactoryStub(null);
-            _consumerScopeFactory =
-                _ =>
-                    new ConsumerScopeFactoryStub(
-                        new ConsumerScopeStub(
-                            new MessageResultBuilder().Build()));
+            _consumerScopeFactory = new ConsumerScopeFactoryStub(new ConsumerScopeStub(new MessageResultBuilder().Build()));
             _registry = new MessageHandlerRegistry();
             _unconfiguredMessageStrategy = new RequireExplicitHandlers();
         }
@@ -40,8 +33,7 @@ namespace Dafda.Tests.Builders
             return this;
         }
 
-        public ConsumerBuilder WithConsumerScopeFactory(
-            Func<ILoggerFactory, IConsumerScopeFactory> consumerScopeFactory)
+        public ConsumerBuilder WithConsumerScopeFactory(IConsumerScopeFactory consumerScopeFactory)
         {
             _consumerScopeFactory = consumerScopeFactory;
             return this;
@@ -75,7 +67,7 @@ namespace Dafda.Tests.Builders
             new Consumer(
                 _registry,
                 _unitOfWorkFactory,
-                _consumerScopeFactory(NullLoggerFactory.Instance),
+                _consumerScopeFactory,
                 _unconfiguredMessageStrategy,
                 _messageFilter,
                 _enableAutoCommit);

--- a/src/Dafda.Tests/Builders/JsonIncomingMessageFactoryBuilder.cs
+++ b/src/Dafda.Tests/Builders/JsonIncomingMessageFactoryBuilder.cs
@@ -1,0 +1,9 @@
+﻿using Dafda.Consuming;
+
+namespace Dafda.Tests.Builders
+{
+    internal class JsonIncomingMessageFactoryBuilder
+    {
+        public JsonIncomingMessageFactory Build() => new JsonIncomingMessageFactory();
+    }
+}

--- a/src/Dafda.Tests/Configuration/TestServiceScope.cs
+++ b/src/Dafda.Tests/Configuration/TestServiceScope.cs
@@ -42,14 +42,13 @@ namespace Dafda.Tests.Configuration
                 .WithGroupId("dummy")
                 .WithBootstrapServers("dummy")
                 .RegisterMessageHandler<DummyMessage, DummyMessageHandler>("dummyTopic", nameof(DummyMessage))
-                .WithConsumerScopeFactory(_ => new ConsumerScopeFactoryStub(new ConsumerScopeStub(messageResult)))
                 .WithUnitOfWorkFactory(new ServiceProviderUnitOfWorkFactory(serviceProvider))
                 .Build();
 
             var consumer = new ConsumerBuilder()
                 .WithMessageHandlerRegistry(consumerConfiguration.MessageHandlerRegistry)
                 .WithUnitOfWorkFactory(consumerConfiguration.UnitOfWorkFactory)
-                .WithConsumerScopeFactory(consumerConfiguration.ConsumerScopeFactory)
+                .WithConsumerScopeFactory(new ConsumerScopeFactoryStub(new ConsumerScopeStub(messageResult)))
                 .WithEnableAutoCommit(consumerConfiguration.EnableAutoCommit)
                 .Build();
 
@@ -89,14 +88,13 @@ namespace Dafda.Tests.Configuration
                 .WithGroupId("dummy")
                 .WithBootstrapServers("dummy")
                 .RegisterMessageHandler<DummyMessage, DummyMessageHandler>("dummyTopic", nameof(DummyMessage))
-                .WithConsumerScopeFactory(_ => new ConsumerScopeFactoryStub(new ConsumerScopeStub(messageResult)))
                 .WithUnitOfWorkFactory(new ServiceProviderUnitOfWorkFactory(serviceProvider))
                 .Build();
 
             var consumer = new ConsumerBuilder()
                 .WithMessageHandlerRegistry(consumerConfiguration.MessageHandlerRegistry)
                 .WithUnitOfWorkFactory(consumerConfiguration.UnitOfWorkFactory)
-                .WithConsumerScopeFactory(consumerConfiguration.ConsumerScopeFactory)
+                .WithConsumerScopeFactory(new ConsumerScopeFactoryStub(new ConsumerScopeStub(messageResult)))
                 .WithEnableAutoCommit(consumerConfiguration.EnableAutoCommit)
                 .Build();
 
@@ -136,14 +134,13 @@ namespace Dafda.Tests.Configuration
                 .WithGroupId("dummy")
                 .WithBootstrapServers("dummy")
                 .RegisterMessageHandler<DummyMessage, DummyMessageHandler>("dummyTopic", nameof(DummyMessage))
-                .WithConsumerScopeFactory(_ => new ConsumerScopeFactoryStub(new ConsumerScopeStub(messageResult)))
                 .WithUnitOfWorkFactory(new ServiceProviderUnitOfWorkFactory(serviceProvider))
                 .Build();
 
             var consumer = new ConsumerBuilder()
                 .WithMessageHandlerRegistry(consumerConfiguration.MessageHandlerRegistry)
                 .WithUnitOfWorkFactory(consumerConfiguration.UnitOfWorkFactory)
-                .WithConsumerScopeFactory(consumerConfiguration.ConsumerScopeFactory)
+                .WithConsumerScopeFactory(new ConsumerScopeFactoryStub(new ConsumerScopeStub(messageResult)))
                 .WithEnableAutoCommit(consumerConfiguration.EnableAutoCommit)
                 .Build();
 
@@ -183,14 +180,13 @@ namespace Dafda.Tests.Configuration
                 .WithGroupId("dummy")
                 .WithBootstrapServers("dummy")
                 .RegisterMessageHandler<DummyMessage, DummyMessageHandler>("dummyTopic", nameof(DummyMessage))
-                .WithConsumerScopeFactory(_ => new ConsumerScopeFactoryStub(new ConsumerScopeStub(messageResult)))
                 .WithUnitOfWorkFactory(new ServiceProviderUnitOfWorkFactory(serviceProvider))
                 .Build();
 
             var consumer = new ConsumerBuilder()
                 .WithMessageHandlerRegistry(consumerConfiguration.MessageHandlerRegistry)
                 .WithUnitOfWorkFactory(consumerConfiguration.UnitOfWorkFactory)
-                .WithConsumerScopeFactory(consumerConfiguration.ConsumerScopeFactory)
+                .WithConsumerScopeFactory(new ConsumerScopeFactoryStub(new ConsumerScopeStub(messageResult)))
                 .WithEnableAutoCommit(consumerConfiguration.EnableAutoCommit)
                 .Build();
 

--- a/src/Dafda.Tests/Consuming/TestConsumer.cs
+++ b/src/Dafda.Tests/Consuming/TestConsumer.cs
@@ -78,7 +78,7 @@ namespace Dafda.Tests.Consuming
                     pre: () => orderOfInvocation.AddLast("before"),
                     post: () => orderOfInvocation.AddLast("after")
                 ))
-                .WithConsumerScopeFactory(_ => new ConsumerScopeFactoryStub(new ConsumerScopeStub(dummyMessageResult)))
+                .WithConsumerScopeFactory(new ConsumerScopeFactoryStub(new ConsumerScopeStub(dummyMessageResult)))
                 .WithMessageHandlerRegistry(registry)
                 .Build();
 
@@ -113,7 +113,7 @@ namespace Dafda.Tests.Consuming
             registry.Register(messageRegistrationStub);
 
             var consumer = new ConsumerBuilder()
-                .WithConsumerScopeFactory(_ => consumerScopeFactoryStub)
+                .WithConsumerScopeFactory(consumerScopeFactoryStub)
                 .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
                 .WithMessageHandlerRegistry(registry)
                 .WithEnableAutoCommit(true)
@@ -150,7 +150,7 @@ namespace Dafda.Tests.Consuming
             registry.Register(messageRegistrationStub);
 
             var consumer = new ConsumerBuilder()
-                .WithConsumerScopeFactory(_ => consumerScopeFactoryStub)
+                .WithConsumerScopeFactory(consumerScopeFactoryStub)
                 .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
                 .WithMessageHandlerRegistry(registry)
                 .WithEnableAutoCommit(false)
@@ -179,7 +179,7 @@ namespace Dafda.Tests.Consuming
             registry.Register(messageRegistrationStub);
 
             var consumer = new ConsumerBuilder()
-                .WithConsumerScopeFactory(_ => spy)
+                .WithConsumerScopeFactory(spy)
                 .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
                 .WithMessageHandlerRegistry(registry)
                 .Build();
@@ -208,7 +208,7 @@ namespace Dafda.Tests.Consuming
             registry.Register(messageRegistrationStub);
 
             var consumer = new ConsumerBuilder()
-                .WithConsumerScopeFactory(_ => new ConsumerScopeFactoryStub(spy))
+                .WithConsumerScopeFactory(new ConsumerScopeFactoryStub(spy))
                 .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
                 .WithMessageHandlerRegistry(registry)
                 .Build();
@@ -254,7 +254,7 @@ namespace Dafda.Tests.Consuming
                 registry.Register(messageRegistrationStub);
 
                 var consumer = new ConsumerBuilder()
-                    .WithConsumerScopeFactory(_ => spy)
+                    .WithConsumerScopeFactory(spy)
                     .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
                     .WithMessageHandlerRegistry(registry)
                     .Build();
@@ -296,7 +296,7 @@ namespace Dafda.Tests.Consuming
                 registry.Register(messageRegistrationStub);
 
                 var consumer = new ConsumerBuilder()
-                    .WithConsumerScopeFactory(_ => new ConsumerScopeFactoryStub(spy))
+                    .WithConsumerScopeFactory(new ConsumerScopeFactoryStub(spy))
                     .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
                     .WithMessageHandlerRegistry(registry)
                     .Build();

--- a/src/Dafda.Tests/Consuming/TestJsonIncomingMessageFactory.cs
+++ b/src/Dafda.Tests/Consuming/TestJsonIncomingMessageFactory.cs
@@ -63,6 +63,24 @@ namespace Dafda.Tests.Consuming
             Assert.Equal(2, data.Position.Longitude);
         }
 
+        private const string MalformedMessage = "{\"aliceCooper\":\"Your cruel device, your blood like ice\"}";
+
+        [Fact]
+        public void Malformed_message_throws_exception()
+        {
+            var sut = new JsonIncomingMessageFactory();
+            Assert.ThrowsAny<Exception>(() => sut.Create(MalformedMessage));
+        }
+
+        private const string InvalidMessage = "{This is not json at all}";
+
+        [Fact]
+        public void InvalidMessage_message_throws_exception()
+        {
+            var sut = new JsonIncomingMessageFactory();
+            Assert.ThrowsAny<Exception>(() => sut.Create(InvalidMessage));
+        }
+
         public record VehiclePositionChanged(string AggregateId, string VehicleId, DateTime TimeStamp, Position Position);
         public record Position(double Latitude, double Longitude);
     }

--- a/src/Dafda.Tests/Consuming/TestJsonIncomingMessageFactory.cs
+++ b/src/Dafda.Tests/Consuming/TestJsonIncomingMessageFactory.cs
@@ -1,5 +1,5 @@
 using System;
-using Dafda.Consuming;
+using Dafda.Tests.Builders;
 using Xunit;
 
 namespace Dafda.Tests.Consuming
@@ -11,7 +11,7 @@ namespace Dafda.Tests.Consuming
         [Fact]
         public void Can_access_message_headers()
         {
-            var sut = new JsonIncomingMessageFactory();
+            var sut = new JsonIncomingMessageFactoryBuilder().Build();
 
             var message = sut.Create(MessageJson);
 
@@ -24,7 +24,7 @@ namespace Dafda.Tests.Consuming
         [Fact]
         public void Can_read_message_headers_non_string()
         {
-            var sut = new JsonIncomingMessageFactory();
+            var sut = new JsonIncomingMessageFactoryBuilder().Build();
 
             var message = sut.Create(MessageJsonWithNonStringMetadata);
             
@@ -34,8 +34,8 @@ namespace Dafda.Tests.Consuming
         [Fact]
         public void Can_decode_data_body()
         {
-            var sut = new JsonIncomingMessageFactory();
-            
+            var sut = new JsonIncomingMessageFactoryBuilder().Build();
+
             var message = sut.Create(MessageJson);
             var data = (VehiclePositionChanged) message.ReadDataAs(typeof(VehiclePositionChanged));
 
@@ -51,7 +51,7 @@ namespace Dafda.Tests.Consuming
         [Fact]
         public void Can_read_message_with_non_camel_case_data_fields()
         {
-            var sut = new JsonIncomingMessageFactory();
+            var sut = new JsonIncomingMessageFactoryBuilder().Build();
 
             var message = sut.Create(MessageJsonWithNonCamelCaseFields);
             var data = (VehiclePositionChanged)message.ReadDataAs(typeof(VehiclePositionChanged));
@@ -68,7 +68,7 @@ namespace Dafda.Tests.Consuming
         [Fact]
         public void Malformed_message_throws_exception()
         {
-            var sut = new JsonIncomingMessageFactory();
+            var sut = new JsonIncomingMessageFactoryBuilder().Build();
             Assert.ThrowsAny<Exception>(() => sut.Create(MalformedMessage));
         }
 
@@ -77,7 +77,7 @@ namespace Dafda.Tests.Consuming
         [Fact]
         public void InvalidMessage_message_throws_exception()
         {
-            var sut = new JsonIncomingMessageFactory();
+            var sut = new JsonIncomingMessageFactoryBuilder().Build();
             Assert.ThrowsAny<Exception>(() => sut.Create(InvalidMessage));
         }
 

--- a/src/Dafda.Tests/Consuming/TestJsonIncomingMessageFactory.cs
+++ b/src/Dafda.Tests/Consuming/TestJsonIncomingMessageFactory.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using Dafda.Tests.Builders;
+using System.Text.Json;
 using Xunit;
 
 namespace Dafda.Tests.Consuming
@@ -69,7 +71,7 @@ namespace Dafda.Tests.Consuming
         public void Malformed_message_throws_exception()
         {
             var sut = new JsonIncomingMessageFactoryBuilder().Build();
-            Assert.ThrowsAny<Exception>(() => sut.Create(MalformedMessage));
+            Assert.Throws<KeyNotFoundException>(() => sut.Create(MalformedMessage));
         }
 
         private const string InvalidMessage = "{This is not json at all}";
@@ -78,7 +80,7 @@ namespace Dafda.Tests.Consuming
         public void InvalidMessage_message_throws_exception()
         {
             var sut = new JsonIncomingMessageFactoryBuilder().Build();
-            Assert.ThrowsAny<Exception>(() => sut.Create(InvalidMessage));
+            Assert.ThrowsAny<JsonException>(() => sut.Create(InvalidMessage));
         }
 
         public record VehiclePositionChanged(string AggregateId, string VehicleId, DateTime TimeStamp, Position Position);

--- a/src/Dafda.Tests/Consuming/TestPoisonAwareIncomingMessageFactory.cs
+++ b/src/Dafda.Tests/Consuming/TestPoisonAwareIncomingMessageFactory.cs
@@ -1,0 +1,71 @@
+using System;
+using Dafda.Configuration;
+using Dafda.Consuming;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Dafda.Tests.Consuming
+{
+    public class TestPoisonAwareIncomingMessageFactory
+    {
+        [Fact]
+        public void Can_create_valid_transport_level_message()
+        {
+            var dummy = new object();
+            var stub = new IncomingMessageFactoryStub(() => new TransportLevelMessage(new Metadata(), type => dummy));
+            var sut = new PoisonAwareIncomingMessageFactory(NullLogger<PoisonAwareIncomingMessageFactory>.Instance, stub);
+
+            var transportLevelMessage = sut.Create("");
+            var data = transportLevelMessage.ReadDataAs(typeof(object));
+            
+            Assert.Same(dummy, data);
+        }
+
+        [Fact]
+        public void Can_create_transport_level_poison_message()
+        {
+            var stub = new IncomingMessageFactoryStub(() => throw new Exception());
+            var sut = new PoisonAwareIncomingMessageFactory(NullLogger<PoisonAwareIncomingMessageFactory>.Instance, stub);
+
+            var transportLevelMessage = sut.Create("");
+
+            var data = transportLevelMessage.ReadDataAs(typeof(object));
+
+            Assert.IsType<TransportLevelPoisonMessage>(data);
+        }
+
+        [Fact]
+        public void Can_register_poison_aware_inner_message_factory()
+        {
+            var configuration = new ConsumerConfigurationBuilder()
+                .WithGroupId("foo")
+                .WithBootstrapServers("bar")
+                .WithPoisonMessageHandling()
+                .Build();
+
+            var provider = new ServiceCollection()
+                .AddLogging()
+                .BuildServiceProvider();
+
+            var incomingMessageFactory = configuration.IncomingMessageFactory(provider);
+
+            Assert.IsType<PoisonAwareIncomingMessageFactory>(incomingMessageFactory);
+        }
+
+        private class IncomingMessageFactoryStub : IIncomingMessageFactory
+        {
+            private readonly Func<TransportLevelMessage> _factory;
+
+            public IncomingMessageFactoryStub(Func<TransportLevelMessage> factory)
+            {
+                _factory = factory;
+            }
+
+            public TransportLevelMessage Create(string rawMessage)
+            {
+                return _factory();
+            }
+        }
+    }
+}

--- a/src/Dafda/Configuration/ConsumerConfiguration.cs
+++ b/src/Dafda/Configuration/ConsumerConfiguration.cs
@@ -2,26 +2,32 @@ using System;
 using System.Collections.Generic;
 using Dafda.Consuming;
 using Dafda.Consuming.MessageFilters;
-using Microsoft.Extensions.Logging;
 
 namespace Dafda.Configuration
 {
     internal class ConsumerConfiguration
     {
-        public ConsumerConfiguration(IDictionary<string, string> configuration, MessageHandlerRegistry messageHandlerRegistry, 
-            IHandlerUnitOfWorkFactory unitOfWorkFactory, Func<ILoggerFactory, IConsumerScopeFactory> consumerScopeFactory, MessageFilter messageFilter)
+        public ConsumerConfiguration(
+            IDictionary<string, string> configuration,
+            MessageHandlerRegistry messageHandlerRegistry,
+            IHandlerUnitOfWorkFactory unitOfWorkFactory,
+            Func<IServiceProvider, IConsumerScopeFactory> consumerScopeFactory,
+            Func<IServiceProvider, IIncomingMessageFactory> incomingMessageFactory,
+            MessageFilter messageFilter)
         {
             KafkaConfiguration = configuration;
             MessageHandlerRegistry = messageHandlerRegistry;
             UnitOfWorkFactory = unitOfWorkFactory;
             ConsumerScopeFactory = consumerScopeFactory;
+            IncomingMessageFactory = incomingMessageFactory;
             MessageFilter = messageFilter;
         }
 
         public IDictionary<string, string> KafkaConfiguration { get; }
         public MessageHandlerRegistry MessageHandlerRegistry { get; }
         public IHandlerUnitOfWorkFactory UnitOfWorkFactory { get; }
-        public Func<ILoggerFactory, IConsumerScopeFactory> ConsumerScopeFactory { get; }
+        public Func<IServiceProvider, IConsumerScopeFactory> ConsumerScopeFactory { get; }
+        public Func<IServiceProvider, IIncomingMessageFactory> IncomingMessageFactory { get; }
 
         public string GroupId => KafkaConfiguration[ConfigurationKey.GroupId];
 

--- a/src/Dafda/Configuration/ConsumerConfigurationBuilder.cs
+++ b/src/Dafda/Configuration/ConsumerConfigurationBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Dafda.Consuming;
 using Dafda.Consuming.MessageFilters;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Dafda.Configuration
@@ -36,8 +37,8 @@ namespace Dafda.Configuration
 
         private ConfigurationSource _configurationSource = ConfigurationSource.Null;
         private IHandlerUnitOfWorkFactory _unitOfWorkFactory;
-        private Func<ILoggerFactory, IConsumerScopeFactory> _consumerScopeFactory;
-        private IIncomingMessageFactory _incomingMessageFactory = new JsonIncomingMessageFactory();
+        private Func<IServiceProvider, IConsumerScopeFactory> _consumerScopeFactory;
+        private Func<IServiceProvider, IIncomingMessageFactory> _incomingMessageFactory = _ => new JsonIncomingMessageFactory();
         private bool _readFromBeginning;
 
         private MessageFilter _messageFilter = MessageFilter.Default;
@@ -94,7 +95,7 @@ namespace Dafda.Configuration
             return this;
         }
 
-        internal ConsumerConfigurationBuilder WithConsumerScopeFactory(Func<ILoggerFactory, IConsumerScopeFactory> consumerScopeFactory)
+        internal ConsumerConfigurationBuilder WithConsumerScopeFactory(Func<IServiceProvider, IConsumerScopeFactory> consumerScopeFactory)
         {
             _consumerScopeFactory = consumerScopeFactory;
             return this;
@@ -118,7 +119,7 @@ namespace Dafda.Configuration
             return this;
         }
 
-        public ConsumerConfigurationBuilder WithIncomingMessageFactory(IIncomingMessageFactory incomingMessageFactory)
+        public ConsumerConfigurationBuilder WithIncomingMessageFactory(Func<IServiceProvider, IIncomingMessageFactory> incomingMessageFactory)
         {
             _incomingMessageFactory = incomingMessageFactory;
             return this;
@@ -126,7 +127,11 @@ namespace Dafda.Configuration
 
         public ConsumerConfigurationBuilder WithPoisonMessageHandling()
         {
-            _incomingMessageFactory = new PoisonAwareIncomingMessageFactory(_incomingMessageFactory);
+            var inner = _incomingMessageFactory;
+            _incomingMessageFactory = provider => new PoisonAwareIncomingMessageFactory(
+                provider.GetRequiredService<ILogger<PoisonAwareIncomingMessageFactory>>(),
+                inner(provider)
+            );
             return this;
         }
 
@@ -140,22 +145,29 @@ namespace Dafda.Configuration
                 .WithConfigurations(_configurations)
                 .Build();
 
+
             if (_consumerScopeFactory == null)
             {
-                _consumerScopeFactory = loggerFactory => new KafkaBasedConsumerScopeFactory(
-                    loggerFactory: loggerFactory,
-                    configuration: configurations,
-                    topics: _messageHandlerRegistry.GetAllSubscribedTopics(),
-                    incomingMessageFactory: _incomingMessageFactory,
-                    readFromBeginning: _readFromBeginning
-                );
-            }
+                _consumerScopeFactory = provider =>
+                {
+                    var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
 
+                    return new KafkaBasedConsumerScopeFactory(
+                        loggerFactory: loggerFactory,
+                        configuration: configurations,
+                        topics: _messageHandlerRegistry.GetAllSubscribedTopics(),
+                        incomingMessageFactory: _incomingMessageFactory(provider),
+                        readFromBeginning: _readFromBeginning
+                    );
+                };
+            }
+            
             return new ConsumerConfiguration(
                 configuration: configurations,
                 messageHandlerRegistry: _messageHandlerRegistry,
                 unitOfWorkFactory: _unitOfWorkFactory,
                 consumerScopeFactory: _consumerScopeFactory,
+                incomingMessageFactory: _incomingMessageFactory, 
                 messageFilter: _messageFilter
             );
         }

--- a/src/Dafda/Configuration/ConsumerConfigurationBuilder.cs
+++ b/src/Dafda/Configuration/ConsumerConfigurationBuilder.cs
@@ -124,6 +124,12 @@ namespace Dafda.Configuration
             return this;
         }
 
+        public ConsumerConfigurationBuilder WithPoisonMessageHandling()
+        {
+            _incomingMessageFactory = new PoisonAwareIncomingMessageFactory(_incomingMessageFactory);
+            return this;
+        }
+
         internal ConsumerConfiguration Build()
         {
             var configurations = new ConfigurationBuilder()

--- a/src/Dafda/Configuration/ConsumerConfigurationBuilder.cs
+++ b/src/Dafda/Configuration/ConsumerConfigurationBuilder.cs
@@ -118,12 +118,6 @@ namespace Dafda.Configuration
             return this;
         }
 
-        public ConsumerConfigurationBuilder Ignoring(string topic, string messageType)
-        {
-            _messageHandlerRegistry.Register<object, NoOpHandler>(topic, messageType);
-            return this;
-        }
-
         public ConsumerConfigurationBuilder WithIncomingMessageFactory(IIncomingMessageFactory incomingMessageFactory)
         {
             _incomingMessageFactory = incomingMessageFactory;

--- a/src/Dafda/Configuration/ConsumerOptions.cs
+++ b/src/Dafda/Configuration/ConsumerOptions.cs
@@ -136,6 +136,17 @@ namespace Dafda.Configuration
         }
 
         /// <summary>
+        /// If the <see cref="IIncomingMessageFactory"/> throws an exception during message deserialization, 
+        /// Dafda will create a <see cref="TransportLevelPoisonMessage"/> 
+        /// that can be handled by the consumer instead of throwing an exception.
+        /// Note, if you wish to overwrite the default <see cref="IIncomingMessageFactory"/> you should do so before enabling poison message handling
+        /// </summary>
+        public void WithPoisonMessageHandling()
+        {
+            _builder.WithPoisonMessageHandling();
+        }
+
+        /// <summary>
         /// Applies a filter that must be evaluated when consuming events.
         /// If the filter evaluated returns false, the event will not be sent to the registered EventHandler class.
         /// If the filter evaluated returns true, the event will be sent to the registered EventHandler.

--- a/src/Dafda/Configuration/ConsumerOptions.cs
+++ b/src/Dafda/Configuration/ConsumerOptions.cs
@@ -2,7 +2,6 @@ using System;
 using Dafda.Consuming;
 using Dafda.Consuming.MessageFilters;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Dafda.Configuration
 {
@@ -121,7 +120,7 @@ namespace Dafda.Configuration
             _services.AddTransient(implementationFactory);
         }
 
-        internal void WithConsumerScopeFactory(Func<ILoggerFactory, IConsumerScopeFactory> consumerScopeFactory)
+        internal void WithConsumerScopeFactory(Func<IServiceProvider, IConsumerScopeFactory> consumerScopeFactory)
         {
             _builder.WithConsumerScopeFactory(consumerScopeFactory);
         }
@@ -130,7 +129,7 @@ namespace Dafda.Configuration
         /// Override the default Dafda implementation of <see cref="IIncomingMessageFactory"/>.
         /// </summary>
         /// <param name="incomingMessageFactory">A custom implementation of <see cref="IIncomingMessageFactory"/>.</param>
-        public void WithIncomingMessageFactory(IIncomingMessageFactory incomingMessageFactory)
+        public void WithIncomingMessageFactory(Func<IServiceProvider, IIncomingMessageFactory> incomingMessageFactory)
         {
             _builder.WithIncomingMessageFactory(incomingMessageFactory);
         }

--- a/src/Dafda/Configuration/ConsumerServiceCollectionExtensions.cs
+++ b/src/Dafda/Configuration/ConsumerServiceCollectionExtensions.cs
@@ -67,7 +67,7 @@ namespace Dafda.Configuration
                 consumer: new Consumer(
                     configuration.MessageHandlerRegistry,
                     provider.GetRequiredService<IHandlerUnitOfWorkFactory>(),
-                    configuration.ConsumerScopeFactory(provider.GetRequiredService<ILoggerFactory>()),
+                    configuration.ConsumerScopeFactory(provider),
                     provider.GetRequiredService<IUnconfiguredMessageHandlingStrategy>(),
                     configuration.MessageFilter,
                     configuration.EnableAutoCommit

--- a/src/Dafda/Consuming/MessageHandlerContext.cs
+++ b/src/Dafda/Consuming/MessageHandlerContext.cs
@@ -10,7 +10,7 @@ namespace Dafda.Consuming
         /// <summary>
         /// An empty MessageHandlerContext
         /// </summary>
-        [Obsolete("This field is obsolete. Clients should not create new contexts but reuse the context from the handler.")]
+        [Obsolete("This field will be removed in a later version. Clients should not create new contexts but reuse the context from the handler.")]
         public static readonly MessageHandlerContext Empty = new MessageHandlerContext();
 
         private readonly Metadata _metadata;
@@ -18,7 +18,7 @@ namespace Dafda.Consuming
         /// <summary>
         /// Initialize an instance of the MessageHandlerContext
         /// </summary>
-        [Obsolete("Clients should not create new contexts but reuse the context from the handler.")]
+        [Obsolete("This field will be removed in a later version. Clients should not create new contexts but reuse the context from the handler.")]
         public MessageHandlerContext() : this(new Metadata())
         {
         }

--- a/src/Dafda/Consuming/MessageHandlerContext.cs
+++ b/src/Dafda/Consuming/MessageHandlerContext.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Dafda.Consuming
 {
     /// <summary>
@@ -8,6 +10,7 @@ namespace Dafda.Consuming
         /// <summary>
         /// An empty MessageHandlerContext
         /// </summary>
+        [Obsolete("This field is obsolete. Clients should not create new contexts but reuse the context from the handler.")]
         public static readonly MessageHandlerContext Empty = new MessageHandlerContext();
 
         private readonly Metadata _metadata;
@@ -15,6 +18,7 @@ namespace Dafda.Consuming
         /// <summary>
         /// Initialize an instance of the MessageHandlerContext
         /// </summary>
+        [Obsolete("Clients should not create new contexts but reuse the context from the handler.")]
         public MessageHandlerContext() : this(new Metadata())
         {
         }

--- a/src/Dafda/Consuming/PoisonAwareIncomingMessageFactory.cs
+++ b/src/Dafda/Consuming/PoisonAwareIncomingMessageFactory.cs
@@ -1,13 +1,16 @@
 ﻿using System;
+using Microsoft.Extensions.Logging;
 
 namespace Dafda.Consuming
 {
     internal class PoisonAwareIncomingMessageFactory : IIncomingMessageFactory
     {
+        private readonly ILogger<PoisonAwareIncomingMessageFactory> _logger;
         private readonly IIncomingMessageFactory _innerIncomingMessageFactory;
 
-        public PoisonAwareIncomingMessageFactory(IIncomingMessageFactory innerIncomingMessageFactory)
+        public PoisonAwareIncomingMessageFactory(ILogger<PoisonAwareIncomingMessageFactory> logger, IIncomingMessageFactory innerIncomingMessageFactory)
         {
+            _logger = logger;
             _innerIncomingMessageFactory = innerIncomingMessageFactory;
         }
 
@@ -19,7 +22,7 @@ namespace Dafda.Consuming
             }
             catch(Exception ex)
             {
-                //TODO: _logger.LogWarning(ex, "Exception thrown when creating transport level message.");
+                _logger.LogWarning(ex, "Exception thrown when creating transport level message");
                 return new TransportLevelMessage(new Metadata() { Type = TransportLevelPoisonMessage.Type }, (t) => new TransportLevelPoisonMessage(rawMessage, ex));
             }
         }

--- a/src/Dafda/Consuming/PoisonAwareIncomingMessageFactory.cs
+++ b/src/Dafda/Consuming/PoisonAwareIncomingMessageFactory.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Dafda.Consuming
+{
+    internal class PoisonAwareIncomingMessageFactory : IIncomingMessageFactory
+    {
+        private readonly IIncomingMessageFactory _innerIncomingMessageFactory;
+
+        public PoisonAwareIncomingMessageFactory(IIncomingMessageFactory innerIncomingMessageFactory)
+        {
+            _innerIncomingMessageFactory = innerIncomingMessageFactory;
+        }
+
+        public TransportLevelMessage Create(string rawMessage)
+        {
+            try
+            {
+                return _innerIncomingMessageFactory.Create(rawMessage);
+            }
+            catch(Exception ex)
+            {
+                //TODO: _logger.LogWarning(ex, "Exception thrown when creating transport level message.");
+                return new TransportLevelMessage(new Metadata() { Type = TransportLevelPoisonMessage.Type }, (t) => new TransportLevelPoisonMessage(rawMessage, ex));
+            }
+        }
+    }
+}

--- a/src/Dafda/Consuming/TransportLevelPoisonMessage.cs
+++ b/src/Dafda/Consuming/TransportLevelPoisonMessage.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace Dafda.Consuming
+{
+    /// <summary>
+    /// A message that could not be deserialized
+    /// </summary>
+    public class TransportLevelPoisonMessage
+    {
+        /// <summary>
+        /// Friendly type name
+        /// </summary>
+        public static string Type => "transport-level-poison-message";
+
+        /// <summary>
+        /// The raw message as retreived from Kafka
+        /// </summary>
+        public string RawMessage { get; }
+
+        /// <summary>
+        /// The exception thrown when trying to deserialize
+        /// </summary>
+        public Exception DeserializationException { get; }
+
+        /// <summary>
+        /// Create a new instance of <see cref="TransportLevelPoisonMessage"/>
+        /// </summary>
+        /// <param name="rawMessage"></param>
+        /// <param name="deserializationException"></param>
+        public TransportLevelPoisonMessage(string rawMessage, Exception deserializationException)
+        {
+            RawMessage = rawMessage;
+            DeserializationException = deserializationException;
+        }
+    }
+}

--- a/src/Dafda/Producing/Producer.cs
+++ b/src/Dafda/Producing/Producer.cs
@@ -56,7 +56,7 @@ namespace Dafda.Producing
         /// Produce a <paramref name="message"/> on Kafka
         /// </summary>
         /// <param name="message">The message</param>
-        /// <param name="context">Context from the consumer</param>
+        /// <param name="context">Context from the consumer. Supply this to get correlation and causation id on the new message</param>
         public async Task Produce(object message, MessageHandlerContext context)
         {
             await Produce(message, context, new Dictionary<string, string>());
@@ -66,8 +66,8 @@ namespace Dafda.Producing
         /// Produce a <paramref name="message"/> on Kafka
         /// </summary>
         /// <param name="message">The message</param>
-        /// <param name="context">Context from the consumer</param>
-        /// <param name="headers">The message headers</param>
+        /// <param name="context">Context from the consumer. Supply this to get correlation and causation id on the new message</param>
+        /// <param name="headers">Additional message headers</param>
         public async Task Produce(object message, MessageHandlerContext context, Dictionary<string, string> headers)
         {
             var payloadDescriptor = _payloadDescriptorFactory.Create(message, context, headers);


### PR DESCRIPTION
Closes #51 
Allows the client to enable handling of poison level messages. Instead of just throwing an exception when the transport level message could not be created (e.g. due to invalid json), Dafda will create a TransportLevelPoisonMessage. This message can then be handled by the consumer to do whatever, or it could be "swallowed" by the no-op handler.