### PR TITLE
add consumer error handling strategy

### DIFF
--- a/src/Dafda.Tests/TestDoubles/DummyApplicationLifetime.cs
+++ b/src/Dafda.Tests/TestDoubles/DummyApplicationLifetime.cs
@@ -7,10 +7,25 @@ namespace Dafda.Tests.TestDoubles
     {
         public void StopApplication()
         {
-        }
+        } 
 
         public CancellationToken ApplicationStarted { get; }
         public CancellationToken ApplicationStopping { get; }
         public CancellationToken ApplicationStopped { get; }
     }
+    
+    public class ApplicationLifetimeSpy : IHostApplicationLifetime
+    {
+        public void StopApplication()
+        {
+            StopApplicationWasCalled = true;
+        }
+
+        public bool StopApplicationWasCalled { get; private set; }
+
+        public CancellationToken ApplicationStarted { get; }
+        public CancellationToken ApplicationStopping { get; }
+        public CancellationToken ApplicationStopped { get; }
+    }
+
 }

--- a/src/Dafda/Configuration/ConsumerConfiguration.cs
+++ b/src/Dafda/Configuration/ConsumerConfiguration.cs
@@ -13,7 +13,8 @@ namespace Dafda.Configuration
             IHandlerUnitOfWorkFactory unitOfWorkFactory,
             Func<IServiceProvider, IConsumerScopeFactory> consumerScopeFactory,
             Func<IServiceProvider, IIncomingMessageFactory> incomingMessageFactory,
-            MessageFilter messageFilter)
+            MessageFilter messageFilter,
+            ConsumerErrorHandler consumerErrorHandler)
         {
             KafkaConfiguration = configuration;
             MessageHandlerRegistry = messageHandlerRegistry;
@@ -21,6 +22,7 @@ namespace Dafda.Configuration
             ConsumerScopeFactory = consumerScopeFactory;
             IncomingMessageFactory = incomingMessageFactory;
             MessageFilter = messageFilter;
+            ConsumerErrorHandler = consumerErrorHandler;
         }
 
         public IDictionary<string, string> KafkaConfiguration { get; }
@@ -32,6 +34,7 @@ namespace Dafda.Configuration
         public string GroupId => KafkaConfiguration[ConfigurationKey.GroupId];
 
         public MessageFilter MessageFilter { get; }
+        public ConsumerErrorHandler ConsumerErrorHandler { get; }
 
         public bool EnableAutoCommit
         {

--- a/src/Dafda/Configuration/ConsumerConfigurationBuilder.cs
+++ b/src/Dafda/Configuration/ConsumerConfigurationBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Dafda.Consuming;
 using Dafda.Consuming.MessageFilters;
 using Microsoft.Extensions.DependencyInjection;
@@ -42,6 +43,7 @@ namespace Dafda.Configuration
         private bool _readFromBeginning;
 
         private MessageFilter _messageFilter = MessageFilter.Default;
+        private ConsumerErrorHandler _consumerErrorHandler = ConsumerErrorHandler.Default;
 
         public ConsumerConfigurationBuilder WithConfigurationSource(ConfigurationSource configurationSource)
         {
@@ -135,6 +137,12 @@ namespace Dafda.Configuration
             return this;
         }
 
+        public ConsumerConfigurationBuilder WithConsumerErrorHandler(Func<Exception, Task<ConsumerFailureStrategy>> failureEvaluation)
+        {
+            _consumerErrorHandler = new ConsumerErrorHandler(failureEvaluation);
+            return this;
+        }
+
         internal ConsumerConfiguration Build()
         {
             var configurations = new ConfigurationBuilder()
@@ -168,7 +176,8 @@ namespace Dafda.Configuration
                 unitOfWorkFactory: _unitOfWorkFactory,
                 consumerScopeFactory: _consumerScopeFactory,
                 incomingMessageFactory: _incomingMessageFactory, 
-                messageFilter: _messageFilter
+                messageFilter: _messageFilter,
+                consumerErrorHandler: _consumerErrorHandler
             );
         }
     }

--- a/src/Dafda/Configuration/ConsumerFailureStrategy.cs
+++ b/src/Dafda/Configuration/ConsumerFailureStrategy.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Hosting;
+
+namespace Dafda.Configuration
+{
+    /// <summary>
+    /// The different strategies for handling "catastrophic" failures in the consumer.
+    /// </summary>
+    public enum ConsumerFailureStrategy
+    {
+        /// <summary>
+        /// The default failure strategy is to call <see cref="IHostApplicationLifetime.StopApplication"/>,
+        /// which should gracefully shutdown the running application.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// The consumer will be restarted.
+        /// </summary>
+        RestartConsumer,
+    }
+}

--- a/src/Dafda/Configuration/ConsumerOptions.cs
+++ b/src/Dafda/Configuration/ConsumerOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Dafda.Consuming;
 using Dafda.Consuming.MessageFilters;
 using Microsoft.Extensions.DependencyInjection;
@@ -179,6 +180,40 @@ namespace Dafda.Configuration
         public void WithUnconfiguredMessageHandlingStrategy<T>()
             where T: class, IUnconfiguredMessageHandlingStrategy =>
             _services.AddTransient<IUnconfiguredMessageHandlingStrategy, T>();
+
+
+        /// <summary>
+        /// Use the <paramref name="failureEvaluation"></paramref> evaluation method to return the desired
+        /// <see cref="ConsumerFailureStrategy"/>.
+        ///
+        /// <para>
+        ///     Failure Strategies:
+        ///     <list type="table">
+        ///         <listheader>
+        ///             <term>Strategy</term>
+        ///             <description>description</description>
+        ///         </listheader>
+        ///         <item>
+        ///             <term><see cref="ConsumerFailureStrategy.Default"/></term>
+        ///             <description><inheritdoc cref="ConsumerFailureStrategy.Default"/></description>
+        ///         </item>
+        ///         <item>
+        ///             <term><see cref="ConsumerFailureStrategy.RestartConsumer"/></term>
+        ///             <description>
+        ///                 <inheritdoc cref="ConsumerFailureStrategy.RestartConsumer"/>
+        ///                 Evaluation, including restart backoff strategies can be supplied here.
+        ///             </description>
+        ///         </item>
+        ///     </list>
+        /// </para>
+        /// 
+        /// </summary>
+        /// <param name="failureEvaluation">An evaluation function that must return a
+        /// <see cref="ConsumerFailureStrategy"/>.</param>
+        public void WithConsumerErrorHandler(Func<Exception, Task<ConsumerFailureStrategy>> failureEvaluation)
+        {
+            _builder.WithConsumerErrorHandler(failureEvaluation);
+        } 
 
         private class DefaultConfigurationSource : ConfigurationSource
         {

--- a/src/Dafda/Configuration/ConsumerServiceCollectionExtensions.cs
+++ b/src/Dafda/Configuration/ConsumerServiceCollectionExtensions.cs
@@ -72,7 +72,8 @@ namespace Dafda.Configuration
                     configuration.MessageFilter,
                     configuration.EnableAutoCommit
                 ),
-                configuration.GroupId
+                configuration.GroupId,
+                configuration.ConsumerErrorHandler
             );
 
             services.AddTransient<IHostedService, ConsumerHostedService>(HostedServiceFactory);

--- a/src/Dafda/Consuming/ConsumerErrorHandler.cs
+++ b/src/Dafda/Consuming/ConsumerErrorHandler.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+using Dafda.Configuration;
+
+namespace Dafda.Consuming
+{
+    internal sealed class ConsumerErrorHandler
+    {
+        public static readonly ConsumerErrorHandler Default = new(_ => Task.FromResult(ConsumerFailureStrategy.Default));
+
+        private readonly Func<Exception, Task<ConsumerFailureStrategy>> _eval;
+
+        public ConsumerErrorHandler(Func<Exception, Task<ConsumerFailureStrategy>> eval)
+        {
+            _eval = eval;
+        }
+
+        public Task<ConsumerFailureStrategy> Handle(Exception exception)
+        {
+            return _eval(exception);
+        }
+    }
+}

--- a/src/Dafda/Consuming/ConsumerHostedService.cs
+++ b/src/Dafda/Consuming/ConsumerHostedService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Dafda.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -12,39 +13,48 @@ namespace Dafda.Consuming
         private readonly IHostApplicationLifetime _applicationLifetime;
         private readonly Consumer _consumer;
         private readonly string _groupId;
+        private readonly ConsumerErrorHandler _consumerErrorHandler;
 
-        public ConsumerHostedService(ILogger<ConsumerHostedService> logger, IHostApplicationLifetime applicationLifetime, Consumer consumer, string groupId)
+        public ConsumerHostedService(ILogger<ConsumerHostedService> logger, IHostApplicationLifetime applicationLifetime, Consumer consumer, string groupId, ConsumerErrorHandler consumerErrorHandler)
         {
             _logger = logger;
             _applicationLifetime = applicationLifetime;
             _consumer = consumer;
             _groupId = groupId;
+            _consumerErrorHandler = consumerErrorHandler;
         }
 
-        public Task ConsumeAll(CancellationToken stoppingToken)
+        public async Task ConsumeAll(CancellationToken stoppingToken)
         {
-            return _consumer.ConsumeAll(stoppingToken);
-        }
-
-        protected override Task ExecuteAsync(CancellationToken stoppingToken)
-        {
-            return Task.Run(async () =>
+            while (true)
             {
                 try
                 {
                     _logger.LogDebug("ConsumerHostedService [{GroupId}] started", _groupId);
-                    await ConsumeAll(stoppingToken);
+                    await _consumer.ConsumeAll(stoppingToken);
+                    break;
                 }
                 catch (OperationCanceledException)
                 {
                     _logger.LogDebug("ConsumerHostedService [{GroupId}] cancelled", _groupId);
+                    break;
                 }
                 catch (Exception err)
                 {
                     _logger.LogError(err, "Unhandled error occurred while consuming messaging");
-                    _applicationLifetime.StopApplication();
+                    var failureStrategy = await _consumerErrorHandler.Handle(err);
+                    if (failureStrategy == ConsumerFailureStrategy.Default)
+                    {
+                        _applicationLifetime.StopApplication();
+                        break;
+                    }
                 }
-            }, stoppingToken);
+            }
+        }
+
+        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            return Task.Run(async () => { await ConsumeAll(stoppingToken); }, stoppingToken);
         }
     }
 }


### PR DESCRIPTION
Here is a stab at the overall error handling strategy for the consumers. I've left the existing behavior as default and an option to override it when adding/configuring consumers. Right now it can either stop the application (default), or restart the consumer loop. Exponential backoff, monitoring, etc. is completely left to the individual clients.
resolves #1 