### PR TITLE
Update Confluent.Kafka library to version 1.8.2

### DIFF
--- a/src/Dafda/Dafda.csproj
+++ b/src/Dafda/Dafda.csproj
@@ -7,7 +7,7 @@
     <Description>A small client for Kafka</Description>
     <RepositoryUrl>https://github.com/dfds/dafda</RepositoryUrl>
     <PackageProjectUrl>https://github.com/dfds/dafda</PackageProjectUrl>
-    <Version>0.11.1</Version>
+    <Version>0.11.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.5.3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.8.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
 


### PR DESCRIPTION
Includes enhancements, fixes, and **security** updates since 1.5.3.

For details see:
-  Version referenced: https://github.com/confluentinc/confluent-kafka-dotnet/releases/tag/v1.8.2
-  Changes from 1.5.3 - 1.8.2: https://github.com/confluentinc/confluent-kafka-dotnet/releases