### PR TITLE
Update Confluent.Kafka library to version 1.9.2

### DIFF
--- a/src/Dafda/Dafda.csproj
+++ b/src/Dafda/Dafda.csproj
@@ -7,7 +7,7 @@
     <Description>A small client for Kafka</Description>
     <RepositoryUrl>https://github.com/dfds/dafda</RepositoryUrl>
     <PackageProjectUrl>https://github.com/dfds/dafda</PackageProjectUrl>
-    <Version>0.11.2</Version>
+    <Version>0.11.3</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.8.2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.9.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
 


### PR DESCRIPTION
Includes enhancements and fixes since 1.8.2 and a reference to librdkafka 1.9.2 which includes an Apple M1 build.

For details see:
 * Version referenced: https://github.com/confluentinc/confluent-kafka-dotnet/releases/tag/v1.9.2
 * Changes from 1.8.2-1.9.2: https://github.com/confluentinc/confluent-kafka-dotnet/releases