### PR TITLE
Update Confluent.Kafka library to version 2.0.2

### DIFF
--- a/src/Dafda/Dafda.csproj
+++ b/src/Dafda/Dafda.csproj
@@ -7,7 +7,7 @@
     <Description>A small client for Kafka</Description>
     <RepositoryUrl>https://github.com/dfds/dafda</RepositoryUrl>
     <PackageProjectUrl>https://github.com/dfds/dafda</PackageProjectUrl>
-    <Version>0.11.3</Version>
+    <Version>0.11.4</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.9.2" />
+    <PackageReference Include="Confluent.Kafka" Version="2.0.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
 


### PR DESCRIPTION
Includes enhancements and fixes since 1.9.2 and a reference to librdkafka 2.0.2 which includes a fix that should improve consumer group rebalancing.

For details see:
 * Version referenced: https://github.com/confluentinc/confluent-kafka-dotnet/releases/tag/v2.0.2
 * Changes from 1.9.2-2.0.2: https://github.com/confluentinc/confluent-kafka-dotnet/releases