### PR TITLE
Add OpenTelemetry Tracing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,10 @@ name: Dafda CI Release
 on:
   push:
     branches:
-      - master
+      - "master"
     tags:
       - "*.*.*"
+      - "0.[0-9]+.[0-9]+-*"
 
 jobs:
   build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,3 +57,10 @@ services:
       KAFKA_SCHEMA_REGISTRY_URL: "schemaregistry:8081"
       #KAFKA_LOG4J_ROOT_LOGLEVEL: INFO
       KAFKA_JMX_PORT: 9991
+
+  jaeger:
+    image: jaegertracing/opentelemetry-all-in-one
+    ports:
+      - "13133:13133"
+      - "16686:16686"
+      - "4317:55680"

--- a/src/Dafda.Tests/Builders/ConsumerBuilder.cs
+++ b/src/Dafda.Tests/Builders/ConsumerBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using Dafda.Consuming;
 using Dafda.Consuming.MessageFilters;
 using Dafda.Tests.TestDoubles;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Dafda.Tests.Builders
 {
@@ -65,9 +64,7 @@ namespace Dafda.Tests.Builders
         }
 
         public Consumer Build() =>
-            new Consumer(
-                NullLogger<Consumer>.Instance, 
-                _registry,
+            new Consumer(_registry,
                 _unitOfWorkFactory,
                 _consumerScopeFactory,
                 _unconfiguredMessageStrategy,

--- a/src/Dafda.Tests/Builders/ConsumerBuilder.cs
+++ b/src/Dafda.Tests/Builders/ConsumerBuilder.cs
@@ -64,7 +64,8 @@ namespace Dafda.Tests.Builders
         }
 
         public Consumer Build() =>
-            new Consumer(_registry,
+            new Consumer(
+                _registry,
                 _unitOfWorkFactory,
                 _consumerScopeFactory,
                 _unconfiguredMessageStrategy,

--- a/src/Dafda.Tests/Builders/ConsumerBuilder.cs
+++ b/src/Dafda.Tests/Builders/ConsumerBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using Dafda.Consuming;
 using Dafda.Consuming.MessageFilters;
 using Dafda.Tests.TestDoubles;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Dafda.Tests.Builders
 {
@@ -65,6 +66,7 @@ namespace Dafda.Tests.Builders
 
         public Consumer Build() =>
             new Consumer(
+                NullLogger<Consumer>.Instance, 
                 _registry,
                 _unitOfWorkFactory,
                 _consumerScopeFactory,

--- a/src/Dafda.Tests/Builders/TransportLevelMessageBuilder.cs
+++ b/src/Dafda.Tests/Builders/TransportLevelMessageBuilder.cs
@@ -14,14 +14,18 @@ namespace Dafda.Tests.Builders
             _data = null;
         }
 
-        public TransportLevelMessageBuilder WithType(string type)
+        public TransportLevelMessageBuilder WithType(string type, string traceparent=null, string baggage=null)
         {
-            _metadata = new Metadata()
+            _metadata = new Metadata
             {
                 MessageId = "foo-message-id",
                 CorrelationId = "foo-correlation-id",
-                Type = type
+                Type = type,
             };
+
+            _metadata["traceparent"] = traceparent;
+            _metadata["baggage"] = baggage;
+
             return this;
         }
 

--- a/src/Dafda.Tests/Configuration/TestConsumerServiceCollectionExtensions.cs
+++ b/src/Dafda.Tests/Configuration/TestConsumerServiceCollectionExtensions.cs
@@ -1,12 +1,17 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Dafda.Configuration;
 using Dafda.Consuming;
+using Dafda.Serializing;
 using Dafda.Tests.Builders;
 using Dafda.Tests.TestDoubles;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
 using Xunit;
 
 namespace Dafda.Tests.Configuration
@@ -47,6 +52,80 @@ namespace Dafda.Tests.Configuration
                 await consumerHostedService.ConsumeAll(cts.Token);
             }
 
+            Assert.Equal(dummyMessage, DummyMessageHandler.LastHandledMessage);
+        }
+
+        [Fact( /*Skip = "is this relevant for testing these extensions"*/)]
+        public async Task Can_consume_message_with_activity()
+        {
+            Consumer.Propagator = new CompositeTextMapPropagator(
+                new TextMapPropagator[]
+                {
+                    new TraceContextPropagator(),
+                    new BaggagePropagator()
+                });
+
+            var wasStarted = false;
+            var wasStopped = false;
+
+            var activityListener = new ActivityListener
+            {
+                ShouldListenTo = s => s.Name == "Dafda",
+                SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStarted = _ => { wasStarted = true; },
+                ActivityStopped = _ => { wasStopped = true; }
+            };
+            ActivitySource.AddActivityListener(activityListener);
+
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            Activity.ForceDefaultIdFormat = true;
+
+            var traceId = ActivityTraceId.CreateRandom();
+            var spanId = ActivitySpanId.CreateRandom();
+            var flags = (byte)ActivityTraceFlags.Recorded;
+            var flagsChars = flags.ToString("x2");
+            string parentId = "00-" + traceId + "-" + spanId + "-" + flagsChars;
+
+            var dummyMessage = new DummyMessage();
+            var messageStub = new TransportLevelMessageBuilder()
+                .WithType(nameof(DummyMessage), parentId, "som=der")
+                .WithData(dummyMessage)
+                .Build();
+            var messageResult = new MessageResultBuilder()
+                .WithTransportLevelMessage(messageStub)
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton<IHostApplicationLifetime, DummyApplicationLifetime>();
+            services.AddConsumer(options =>
+            {
+                options.WithBootstrapServers("dummyBootstrapServer");
+                options.WithGroupId("dummyGroupId");
+                options.RegisterMessageHandler<DummyMessage, DummyMessageHandler>("dummyTopic", nameof(DummyMessage));
+
+                options.WithConsumerScopeFactory(_ => new ConsumerScopeFactoryStub(new ConsumerScopeStub(messageResult)));
+            });
+            var serviceProvider = services.BuildServiceProvider();
+
+            var consumerHostedService = serviceProvider.GetServices<IHostedService>()
+                .OfType<ConsumerHostedService>()
+                .First();
+
+            using (var cts = new CancellationTokenSource(50))
+            {
+                await consumerHostedService.ConsumeAll(cts.Token);
+            }
+
+            Assert.Equal(parentId, DummyMessageHandler.LastActivityParentId);
+            Assert.Equal(new Dictionary<string, string>
+            {
+                { "som", "der" }
+            }, DummyMessageHandler.LastBaggage.GetBaggage());
+
+            Assert.True(wasStarted);
+            Assert.True(wasStopped);
             Assert.Equal(dummyMessage, DummyMessageHandler.LastHandledMessage);
         }
 
@@ -190,10 +269,18 @@ namespace Dafda.Tests.Configuration
             {
                 LastHandledMessage = message;
 
+                LastActivityParentId = Activity.Current?.ParentId;
+                LastActivityId = Activity.Current?.Id;
+                LastBaggage = Baggage.Current;
+
                 return Task.CompletedTask;
             }
 
+            public static string? LastActivityParentId { get; private set; }
+            public static string? LastActivityId { get; private set; }
+
             public static object LastHandledMessage { get; private set; }
+            public static Baggage LastBaggage { get; private set; }
         }
 
         private class FailingConsumerScopeFactory : IConsumerScopeFactory

--- a/src/Dafda.Tests/Configuration/TestConsumerServiceCollectionExtensions.cs
+++ b/src/Dafda.Tests/Configuration/TestConsumerServiceCollectionExtensions.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Dafda.Configuration;
 using Dafda.Consuming;
 using Dafda.Diagnostics;
-using Dafda.Serializing;
 using Dafda.Tests.Builders;
 using Dafda.Tests.TestDoubles;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Dafda.Tests/Configuration/TestConsumerServiceCollectionExtensions.cs
+++ b/src/Dafda.Tests/Configuration/TestConsumerServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dafda.Configuration;
 using Dafda.Consuming;
+using Dafda.Diagnostics;
 using Dafda.Serializing;
 using Dafda.Tests.Builders;
 using Dafda.Tests.TestDoubles;
@@ -58,7 +59,7 @@ namespace Dafda.Tests.Configuration
         [Fact( /*Skip = "is this relevant for testing these extensions"*/)]
         public async Task Can_consume_message_with_activity()
         {
-            Consumer.Propagator = new CompositeTextMapPropagator(
+            ConsumerActivitySource.Propagator = new CompositeTextMapPropagator(
                 new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
@@ -140,7 +141,7 @@ namespace Dafda.Tests.Configuration
                 options.WithBootstrapServers("dummyBootstrapServer");
                 options.WithGroupId("dummyGroupId");
             });
-            
+
             var serviceProvider = services.BuildServiceProvider();
             var consumerHostedServices = serviceProvider
                 .GetServices<IHostedService>()
@@ -156,19 +157,19 @@ namespace Dafda.Tests.Configuration
 
             services.AddLogging();
             services.AddSingleton<IHostApplicationLifetime, DummyApplicationLifetime>();
-            
+
             services.AddConsumer(options =>
             {
                 options.WithBootstrapServers("dummyBootstrapServer");
                 options.WithGroupId("dummyGroupId 1");
             });
-            
+
             services.AddConsumer(options =>
             {
                 options.WithBootstrapServers("dummyBootstrapServer");
                 options.WithGroupId("dummyGroupId 2");
             });
-            
+
             var serviceProvider = services.BuildServiceProvider();
             var consumerHostedServices = serviceProvider
                 .GetServices<IHostedService>()

--- a/src/Dafda.Tests/Producing/TestOutgoingMessageFactory.cs
+++ b/src/Dafda.Tests/Producing/TestOutgoingMessageFactory.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Dafda.Tests.Helpers;
 using Dafda.Tests.TestDoubles;
 using Xunit;

--- a/src/Dafda.Tests/Producing/TestProducer.cs
+++ b/src/Dafda.Tests/Producing/TestProducer.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Dafda.Consuming;
 using Dafda.Diagnostics;
-using Dafda.Serializing;
 using Dafda.Tests.Helpers;
 using Dafda.Tests.TestDoubles;
 using OpenTelemetry;

--- a/src/Dafda.Tests/Producing/TestProducer.cs
+++ b/src/Dafda.Tests/Producing/TestProducer.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Dafda.Consuming;
+using Dafda.Diagnostics;
 using Dafda.Serializing;
 using Dafda.Tests.Helpers;
 using Dafda.Tests.TestDoubles;
@@ -93,7 +94,7 @@ namespace Dafda.Tests.Producing
         public async Task produces_message_with_expected_serialized_value()
         {
             var expectedValue = "foo-value";
-            
+
             var spy = new KafkaProducerSpy(new PayloadSerializerStub(expectedValue));
 
             var sut = A.Producer
@@ -200,7 +201,7 @@ namespace Dafda.Tests.Producing
                 )
                 .Build();
 
-            await sut.Produce( 
+            await sut.Produce(
                 message: new Message { Id = expectedKey },
                 headers: new Metadata
                 {
@@ -235,7 +236,7 @@ namespace Dafda.Tests.Producing
                 })
             );
 
- 
+
             var expected = @"
                             {
                             ""messageId"":""1"",
@@ -253,7 +254,7 @@ namespace Dafda.Tests.Producing
         [Fact]
         public async Task produces_expected_message_without_headers_using_default_serializer_and_activity_source()
         {
-            DefaultPayloadSerializer.Propagator = new CompositeTextMapPropagator(
+            ProducerActivitySource.Propagator = new CompositeTextMapPropagator(
                 new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
@@ -295,7 +296,7 @@ namespace Dafda.Tests.Producing
                                 ""type"":""bar"",
                                 ""causationId"":""1"",
                                 ""correlationId"":""1"",
-                                ""traceparent"":""{spy.ActivityId}"",
+                                ""traceparent"":""{spy.ProducerActivityId}"",
                                 ""baggage"":""som=der"",
                                 ""data"":{{
                                     ""id"":""dummyId""

--- a/src/Dafda.Tests/Producing/TestProducer.cs
+++ b/src/Dafda.Tests/Producing/TestProducer.cs
@@ -252,7 +252,7 @@ namespace Dafda.Tests.Producing
         }
 
         [Fact]
-        public async Task produces_expected_message_without_headers_using_default_serializer_and_activity_source()
+        public async Task produces_message_with_traceparent_and_baggage_propagation_in_header()
         {
             ProducerActivitySource.Propagator = new CompositeTextMapPropagator(
                 new TextMapPropagator[]

--- a/src/Dafda.Tests/TestDoubles/KafkaProducerSpy.cs
+++ b/src/Dafda.Tests/TestDoubles/KafkaProducerSpy.cs
@@ -31,7 +31,7 @@ namespace Dafda.Tests.TestDoubles
             Key = key;
             Value = value;
 
-            ActivityId = Activity.Current?.Id;
+            ProducerActivityId = Activity.Current?.Parent?.Id;
 
             return Task.CompletedTask;
         }
@@ -48,6 +48,6 @@ namespace Dafda.Tests.TestDoubles
         public string Key { get; private set; }
         public string Value { get; private set; }
 
-        public string ActivityId { get; private set; }
+        public string ProducerActivityId { get; private set; }
     }
 }

--- a/src/Dafda.Tests/TestDoubles/KafkaProducerSpy.cs
+++ b/src/Dafda.Tests/TestDoubles/KafkaProducerSpy.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Dafda.Producing;
@@ -30,6 +31,8 @@ namespace Dafda.Tests.TestDoubles
             Key = key;
             Value = value;
 
+            ActivityId = Activity.Current?.Id;
+
             return Task.CompletedTask;
         }
 
@@ -44,5 +47,7 @@ namespace Dafda.Tests.TestDoubles
         public string Topic { get; private set; }
         public string Key { get; private set; }
         public string Value { get; private set; }
+
+        public string ActivityId { get; private set; }
     }
 }

--- a/src/Dafda/Configuration/ConsumerConfigurationBase.cs
+++ b/src/Dafda/Configuration/ConsumerConfigurationBase.cs
@@ -1,8 +1,6 @@
 ﻿using Dafda.Consuming.Interfaces;
 using Dafda.Consuming;
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Dafda.Configuration
 {

--- a/src/Dafda/Configuration/ConsumerServiceCollectionExtensions.cs
+++ b/src/Dafda/Configuration/ConsumerServiceCollectionExtensions.cs
@@ -64,7 +64,8 @@ namespace Dafda.Configuration
             ConsumerHostedService HostedServiceFactory(IServiceProvider provider) => new ConsumerHostedService(
                 logger: provider.GetRequiredService<ILogger<ConsumerHostedService>>(),
                 applicationLifetime: provider.GetRequiredService<IHostApplicationLifetime>(),
-                consumer: new Consumer(configuration.MessageHandlerRegistry,
+                consumer: new Consumer(
+                    configuration.MessageHandlerRegistry,
                     provider.GetRequiredService<IHandlerUnitOfWorkFactory>(),
                     configuration.ConsumerScopeFactory(provider),
                     provider.GetRequiredService<IUnconfiguredMessageHandlingStrategy>(),

--- a/src/Dafda/Configuration/ConsumerServiceCollectionExtensions.cs
+++ b/src/Dafda/Configuration/ConsumerServiceCollectionExtensions.cs
@@ -65,6 +65,7 @@ namespace Dafda.Configuration
                 logger: provider.GetRequiredService<ILogger<ConsumerHostedService>>(),
                 applicationLifetime: provider.GetRequiredService<IHostApplicationLifetime>(),
                 consumer: new Consumer(
+                    provider.GetRequiredService<ILogger<Consumer>>(),
                     configuration.MessageHandlerRegistry,
                     provider.GetRequiredService<IHandlerUnitOfWorkFactory>(),
                     configuration.ConsumerScopeFactory(provider),

--- a/src/Dafda/Configuration/ConsumerServiceCollectionExtensions.cs
+++ b/src/Dafda/Configuration/ConsumerServiceCollectionExtensions.cs
@@ -64,9 +64,7 @@ namespace Dafda.Configuration
             ConsumerHostedService HostedServiceFactory(IServiceProvider provider) => new ConsumerHostedService(
                 logger: provider.GetRequiredService<ILogger<ConsumerHostedService>>(),
                 applicationLifetime: provider.GetRequiredService<IHostApplicationLifetime>(),
-                consumer: new Consumer(
-                    provider.GetRequiredService<ILogger<Consumer>>(),
-                    configuration.MessageHandlerRegistry,
+                consumer: new Consumer(configuration.MessageHandlerRegistry,
                     provider.GetRequiredService<IHandlerUnitOfWorkFactory>(),
                     configuration.ConsumerScopeFactory(provider),
                     provider.GetRequiredService<IUnconfiguredMessageHandlingStrategy>(),

--- a/src/Dafda/Consuming/Consumer.cs
+++ b/src/Dafda/Consuming/Consumer.cs
@@ -64,21 +64,21 @@ internal class Consumer
         var parentContext = Propagator.Extract(default, message.Metadata, ExtractFromMetadata);
         Baggage.Current = parentContext.Baggage;
 
-        using var activity = DafdaActivitySource.ActivitySource.StartActivity("<topic> receive", ActivityKind.Consumer, parentContext.ActivityContext);
+        using var activity = DafdaActivitySource.ActivitySource.StartActivity($"{messageResult.Topic} receive", ActivityKind.Consumer, parentContext.ActivityContext);
         activity?.SetTag("messaging.system", "kafka");
-        activity?.SetTag("messaging.destination", "<topic>");
+        activity?.SetTag("messaging.destination", messageResult.Topic);
         activity?.SetTag("messaging.destination_kind", "topic");
         activity?.SetTag("messaging.message_id", message.Metadata.MessageId);
         activity?.SetTag("messaging.conversation_id", message.Metadata.CorrelationId);
         //activity?.SetTag("messaging.message_payload_size_bytes", "0");
         // consumer
         activity?.SetTag("messaging.operation", "receive");
-        activity?.SetTag("messaging.consumer_id", "<consumer_group> - <client_id>");
+        activity?.SetTag("messaging.consumer_id", $"{messageResult.GroupId} - {messageResult.ClientId}");
         // kafka
-        //activity?.SetTag("messaging.kafka.message_key", "partition_key");
-        //activity?.SetTag("messaging.kafka.consumer_group", "consumer_group");
-        //activity?.SetTag("messaging.kafka.client_id", "client_id");
-        //activity?.SetTag("messaging.kafka.partition", "partition");
+        activity?.SetTag("messaging.kafka.message_key", messageResult.PartitionKey);
+        activity?.SetTag("messaging.kafka.consumer_group", messageResult.GroupId);
+        activity?.SetTag("messaging.kafka.client_id", messageResult.ClientId);
+        activity?.SetTag("messaging.kafka.partition", messageResult.Partition);
 
         if (_messageFilter.CanAcceptMessage(messageResult))
             await _localMessageDispatcher.Dispatch(message);

--- a/src/Dafda/Consuming/Consumer.cs
+++ b/src/Dafda/Consuming/Consumer.cs
@@ -14,7 +14,8 @@ namespace Dafda.Consuming
         private readonly LocalMessageDispatcher _localMessageDispatcher;
         private readonly MessageFilter _messageFilter;
 
-        public Consumer(MessageHandlerRegistry messageHandlerRegistry,
+        public Consumer(
+            MessageHandlerRegistry messageHandlerRegistry,
             IHandlerUnitOfWorkFactory unitOfWorkFactory,
             IConsumerScopeFactory consumerScopeFactory,
             IUnconfiguredMessageHandlingStrategy fallbackHandler,

--- a/src/Dafda/Consuming/Consumer.cs
+++ b/src/Dafda/Consuming/Consumer.cs
@@ -1,16 +1,10 @@
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Dafda.Configuration;
+using Dafda.Diagnostics;
 using Dafda.Consuming.Interfaces;
 using Dafda.Consuming.MessageFilters;
-using Dafda.Serializing;
 using Microsoft.Extensions.Logging;
-using OpenTelemetry;
-using OpenTelemetry.Context.Propagation;
 
 namespace Dafda.Consuming
 {
@@ -68,122 +62,15 @@ namespace Dafda.Consuming
             using var scope = _logger.BeginScope("{TraceParent}", messageResult.Message.Metadata["traceparent"]);
 
             var message = messageResult.Message;
-            var parentContext = Propagator.Extract(default, message.Metadata, ExtractFromMetadata);
-            Baggage.Current = parentContext.Baggage;
-
-            using var activity = DafdaActivitySource.Consumer.StartActivity(messageResult, parentContext.ActivityContext);
-            _logger.LogDebug("Starting new activity Consumer:{ParentActivityId}:{ActivityId}", activity?.ParentId, activity?.Id);
+            using var activity = ConsumerActivitySource.StartActivity(messageResult);
+            _logger.LogDebug("Starting new activity Consumer:{ParentActivityId}:{ActivityId}", activity?.ParentId,
+                activity?.Id);
 
             if (_messageFilter.CanAcceptMessage(messageResult))
                 await _localMessageDispatcher.Dispatch(message);
 
             if (!_isAutoCommitEnabled)
                 await messageResult.Commit();
-        }
-
-        public static TextMapPropagator Propagator { get; set; } = Propagators.DefaultTextMapPropagator;
-
-        private static IEnumerable<string> ExtractFromMetadata(Metadata metadata, string key)
-        {
-            yield return metadata[key];
-        }
-
-    }
-
-    internal static class DafdaActivitySource
-    {
-        public static readonly AssemblyName AssemblyName = typeof(KafkaConsumerScope).Assembly.GetName();
-        public static readonly ActivitySource ActivitySource = new(AssemblyName.Name, AssemblyName.Version.ToString());
-
-        public static readonly IActivityBuilder<MessageResult> Consumer = new ConsumerActivityBuilder();
-
-        private const string MessagingSystem = "kafka";
-        private const string DestinationKind = "topic";
-        private const string OperationReceive = "receive";
-        private const string OperationPublish = "publish";
-
-        internal interface IActivityBuilder<in T>
-        {
-            Activity StartActivity(T data, ActivityContext parentContext);
-        }
-
-        internal class ConsumerActivityBuilder : IActivityBuilder<MessageResult>
-        {
-            private const string ConsumerActivityNameSuffix = "receive";
-
-            public Activity StartActivity(MessageResult data, ActivityContext parentContext)
-            {
-                return ActivitySource
-                    .StartActivity($"{data.Topic} {ConsumerActivityNameSuffix}", ActivityKind.Consumer, parentContext)
-                    .AddDefaultOpenTelemetryTags(
-                        topicName: data.Topic,
-                        messageId: data.Message.Metadata.MessageId,
-                        conversationId : data.Message.Metadata.CorrelationId,
-                        clientId: data.ClientId,
-                        partitionKey: data.PartitionKey,
-                        partition: data.Partition)
-                    .AddConsumerOpenTelemetryTags(
-                        groupId: data.GroupId);
-            }
-
-        }
-
-        internal class ProducerActivityBuilder : IActivityBuilder<PayloadDescriptor>
-        {
-            private const string ProducerActivityNameSuffix = "send";
-
-            public Activity StartActivity(PayloadDescriptor data, ActivityContext parentContext)
-            {
-                return ActivitySource
-                    .StartActivity($"{data.TopicName} {ProducerActivityNameSuffix}", ActivityKind.Producer,
-                        parentContext)
-                    .AddDefaultOpenTelemetryTags(
-                        topicName: data.TopicName,
-                        messageId: data.MessageId,
-                        conversationId: "",
-                        clientId: data.ClientId,
-                        partitionKey: data.PartitionKey,
-                        partition: 0)
-                    .AddProducerOpenTelemetryTags();
-            }
-        }
-
-        private static Activity AddDefaultOpenTelemetryTags(this Activity activity,
-            string topicName,
-            string messageId,
-            string conversationId,
-            string clientId,
-            string partitionKey,
-            int partition)
-        {
-            // messaging tags
-            activity.SetTag(OpenTelemetryMessagingAttributes.SYSTEM, MessagingSystem);
-            activity.SetTag(OpenTelemetryMessagingAttributes.DESTINATION_KIND, DestinationKind);
-
-            activity.SetTag(OpenTelemetryMessagingAttributes.DESTINATION, topicName);
-            activity.SetTag(OpenTelemetryMessagingAttributes.MESSAGE_ID, messageId);
-            activity.SetTag(OpenTelemetryMessagingAttributes.CONVERSATION_ID, conversationId);
-            activity.SetTag(OpenTelemetryMessagingAttributes.CLIENT_ID, clientId);
-
-            // kafka specific tags
-            activity.SetTag(OpenTelemetryMessagingAttributes.KAFKA_MESSAGE_KEY, partitionKey);
-            activity.SetTag(OpenTelemetryMessagingAttributes.KAFKA_PARTITION, partition);
-
-            return activity;
-        }
-
-
-        public static Activity AddConsumerOpenTelemetryTags(this Activity activity, string groupId)
-        {
-            activity.SetTag(OpenTelemetryMessagingAttributes.KAFKA_CONSUMER_GROUP, groupId);
-            activity.SetTag(OpenTelemetryMessagingAttributes.OPERATION, OperationReceive);
-            return activity;
-        }
-
-        public static Activity AddProducerOpenTelemetryTags(this Activity activity)
-        {
-            activity.SetTag(OpenTelemetryMessagingAttributes.OPERATION, OperationPublish);
-            return activity;
         }
     }
 }

--- a/src/Dafda/Consuming/Interfaces/IConsumer.cs
+++ b/src/Dafda/Consuming/Interfaces/IConsumer.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using System.Threading;
 
 namespace Dafda.Consuming.Interfaces

--- a/src/Dafda/Consuming/Interfaces/IConsumerErrorHandler.cs
+++ b/src/Dafda/Consuming/Interfaces/IConsumerErrorHandler.cs
@@ -1,7 +1,5 @@
 ﻿using Dafda.Configuration;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Dafda.Consuming.Interfaces

--- a/src/Dafda/Consuming/KafkaBasedConsumerScopeFactory.cs
+++ b/src/Dafda/Consuming/KafkaBasedConsumerScopeFactory.cs
@@ -22,7 +22,7 @@ namespace Dafda.Consuming
             _incomingMessageFactory = incomingMessageFactory;
             _readFromBeginning = readFromBeginning;
         }
-        
+
         public ConsumerScope CreateConsumerScope()
         {
             var consumerBuilder = new ConsumerBuilder<string, string>(_configuration);
@@ -34,7 +34,8 @@ namespace Dafda.Consuming
             var consumer = consumerBuilder.Build();
             consumer.Subscribe(_topics);
 
-            var groupId = _configuration.FirstOrDefault(x => x.Key==ConfigurationKey.GroupId).Value;
+            // at this stage, groupId must be present in the configuration
+            var groupId = _configuration.First(x => x.Key == ConfigurationKey.GroupId).Value;
             return new KafkaConsumerScope(_loggerFactory, consumer, _incomingMessageFactory, groupId);
         }
     }

--- a/src/Dafda/Consuming/KafkaBasedConsumerScopeFactory.cs
+++ b/src/Dafda/Consuming/KafkaBasedConsumerScopeFactory.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Confluent.Kafka;
+using Dafda.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Dafda.Consuming
@@ -33,7 +34,8 @@ namespace Dafda.Consuming
             var consumer = consumerBuilder.Build();
             consumer.Subscribe(_topics);
 
-            return new KafkaConsumerScope(_loggerFactory, consumer, _incomingMessageFactory);
+            var groupId = _configuration.FirstOrDefault(x => x.Key==ConfigurationKey.GroupId).Value;
+            return new KafkaConsumerScope(_loggerFactory, consumer, _incomingMessageFactory, groupId);
         }
     }
 }

--- a/src/Dafda/Consuming/KafkaConsumerScope.cs
+++ b/src/Dafda/Consuming/KafkaConsumerScope.cs
@@ -10,12 +10,14 @@ namespace Dafda.Consuming
         private readonly ILogger<KafkaConsumerScope> _logger;
         private readonly IConsumer<string, string> _innerKafkaConsumer;
         private readonly IIncomingMessageFactory _incomingMessageFactory;
+        private readonly string _groupId;
 
-        internal KafkaConsumerScope(ILoggerFactory loggerFactory, IConsumer<string, string> innerKafkaConsumer, IIncomingMessageFactory incomingMessageFactory)
+        internal KafkaConsumerScope(ILoggerFactory loggerFactory, IConsumer<string, string> innerKafkaConsumer, IIncomingMessageFactory incomingMessageFactory, string groupId)
         {
             _logger = loggerFactory.CreateLogger<KafkaConsumerScope>();
             _innerKafkaConsumer = innerKafkaConsumer;
             _incomingMessageFactory = incomingMessageFactory;
+            _groupId = groupId;
         }
 
         public override Task<MessageResult> GetNext(CancellationToken cancellationToken)
@@ -30,7 +32,14 @@ namespace Dafda.Consuming
                 {
                     _innerKafkaConsumer.Commit(innerResult);
                     return Task.CompletedTask;
-                });
+                })
+            {
+                Topic = innerResult.Topic,
+                Partition = innerResult.Partition.Value,
+                PartitionKey = innerResult.Message.Key,
+                ClientId = _innerKafkaConsumer.Name,
+                GroupId = _groupId
+            };
 
             return Task.FromResult(result);
         }

--- a/src/Dafda/Consuming/MessageFilters/MultiHeaderMessageFilter.cs
+++ b/src/Dafda/Consuming/MessageFilters/MultiHeaderMessageFilter.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Dafda.Configuration;
-using Dafda.Serializing;
 
 namespace Dafda.Consuming.MessageFilters
 {

--- a/src/Dafda/Consuming/MessageResult.cs
+++ b/src/Dafda/Consuming/MessageResult.cs
@@ -21,10 +21,21 @@ namespace Dafda.Consuming
             _onCommit = onCommit ?? EmptyCommitAction;
         }
 
+        internal string Topic { get; set; }
+        
+        internal int Partition { get; set; }
+
+        internal string PartitionKey { get; set; }
+
+        internal string ClientId { get; set; }
+        
+        internal string GroupId { get; set; }
+
         /// <summary>
         /// Transmitted message consumed from Kafka
         /// </summary>
         public TransportLevelMessage Message { get; }
+
 
         /// <summary>
         /// Commit message to handlers

--- a/src/Dafda/Consuming/Metadata.cs
+++ b/src/Dafda/Consuming/Metadata.cs
@@ -78,7 +78,7 @@ namespace Dafda.Consuming
                 _metadata.TryGetValue(key, out var value);
                 return value;
             }
-            private set => _metadata[key] = value;
+            internal set => _metadata[key] = value;
         }
 
         /// <summary>

--- a/src/Dafda/Dafda.csproj
+++ b/src/Dafda/Dafda.csproj
@@ -7,7 +7,7 @@
     <Description>A small client for Kafka</Description>
     <RepositoryUrl>https://github.com/dfds/dafda</RepositoryUrl>
     <PackageProjectUrl>https://github.com/dfds/dafda</PackageProjectUrl>
-    <Version>0.12.0-otel.1</Version>
+    <Version>0.12.1</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/Dafda/Dafda.csproj
+++ b/src/Dafda/Dafda.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="2.0.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.2.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.7.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
 
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />

--- a/src/Dafda/Dafda.csproj
+++ b/src/Dafda/Dafda.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="1.8.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.2.0-rc4" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
 
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />

--- a/src/Dafda/Dafda.csproj
+++ b/src/Dafda/Dafda.csproj
@@ -7,7 +7,7 @@
     <Description>A small client for Kafka</Description>
     <RepositoryUrl>https://github.com/dfds/dafda</RepositoryUrl>
     <PackageProjectUrl>https://github.com/dfds/dafda</PackageProjectUrl>
-    <Version>0.11.2</Version>
+    <Version>0.12.0-otel.1</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/Dafda/Diagnostics/ConsumerActivitySource.cs
+++ b/src/Dafda/Diagnostics/ConsumerActivitySource.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using Dafda.Consuming;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+
+namespace Dafda.Diagnostics;
+
+internal static class ConsumerActivitySource
+{
+    private const string ActivityNameSuffix = "receive";
+
+    private static readonly AssemblyName AssemblyName = typeof(KafkaConsumerScope).Assembly.GetName();
+    private static readonly ActivitySource ActivitySource = new(AssemblyName.Name, AssemblyName.Version.ToString());
+    public static TextMapPropagator Propagator { get; set; } = Propagators.DefaultTextMapPropagator;
+
+    public static Activity StartActivity(MessageResult @event)
+    {
+        // Extract the context injected in the metadata by the publisher
+        var message = @event.Message;
+        var parentContext = Propagator.Extract(default, message.Metadata, ExtractFromMetadata);
+
+        // Inject extracted info into current context
+        Baggage.Current = parentContext.Baggage;
+
+        // Start the activity
+        return ActivitySource.StartActivity($"{@event.Topic} {ActivityNameSuffix}", ActivityKind.Consumer, parentContext.ActivityContext)
+            .AddDefaultOpenTelemetryTags(
+                topicName: @event.Topic,
+                messageId: @event.Message.Metadata.MessageId,
+                clientId: @event.ClientId,
+                partitionKey: @event.PartitionKey,
+                partition: @event.Partition)
+            .AddConsumerOpenTelemetryTags(
+                groupId: @event.GroupId);
+    }
+
+    private static IEnumerable<string> ExtractFromMetadata(Metadata metadata, string key)
+    {
+        yield return metadata[key];
+    }
+}

--- a/src/Dafda/Diagnostics/OpenTelemetryActivityExtensions.cs
+++ b/src/Dafda/Diagnostics/OpenTelemetryActivityExtensions.cs
@@ -28,17 +28,17 @@ internal static class OpenTelemetryActivityExtensions
             return null;
 
         // messaging tags
-        activity.SetTag(OpenTelemetryMessagingAttributes.SYSTEM, Messaging.System);
-        activity.SetTag(OpenTelemetryMessagingAttributes.DESTINATION_KIND, Messaging.DestinationKind);
+        activity.SetTag(OpenTelemetryMessagingAttributes.System, Messaging.System);
+        activity.SetTag(OpenTelemetryMessagingAttributes.DestinationKind, Messaging.DestinationKind);
 
-        activity.SetTag(OpenTelemetryMessagingAttributes.DESTINATION, topicName);
-        activity.SetTag(OpenTelemetryMessagingAttributes.MESSAGE_ID, messageId);
-        activity.SetTag(OpenTelemetryMessagingAttributes.CLIENT_ID, clientId);
+        activity.SetTag(OpenTelemetryMessagingAttributes.Destination, topicName);
+        activity.SetTag(OpenTelemetryMessagingAttributes.MessageId, messageId);
+        activity.SetTag(OpenTelemetryMessagingAttributes.ClientId, clientId);
 
         // kafka specific tags
-        activity.SetTag(OpenTelemetryMessagingAttributes.KAFKA_MESSAGE_KEY, partitionKey);
+        activity.SetTag(OpenTelemetryMessagingAttributes.KafkaMessageKey, partitionKey);
         if (partition.HasValue)
-            activity.SetTag(OpenTelemetryMessagingAttributes.KAFKA_PARTITION, partition);
+            activity.SetTag(OpenTelemetryMessagingAttributes.KafkaPartition, partition);
 
         return activity;
     }
@@ -48,8 +48,8 @@ internal static class OpenTelemetryActivityExtensions
         if (activity == null)
             return null;
 
-        activity.SetTag(OpenTelemetryMessagingAttributes.KAFKA_CONSUMER_GROUP, groupId);
-        activity.SetTag(OpenTelemetryMessagingAttributes.OPERATION, Operation.Receive);
+        activity.SetTag(OpenTelemetryMessagingAttributes.KafkaConsumerGroup, groupId);
+        activity.SetTag(OpenTelemetryMessagingAttributes.Operation, Operation.Receive);
         return activity;
     }
 
@@ -58,7 +58,7 @@ internal static class OpenTelemetryActivityExtensions
         if (activity == null)
             return null;
 
-        activity.SetTag(OpenTelemetryMessagingAttributes.OPERATION, Operation.Publish);
+        activity.SetTag(OpenTelemetryMessagingAttributes.Operation, Operation.Publish);
         return activity;
     }
 }

--- a/src/Dafda/Diagnostics/OpenTelemetryActivityExtensions.cs
+++ b/src/Dafda/Diagnostics/OpenTelemetryActivityExtensions.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics;
+
+namespace Dafda.Diagnostics;
+
+internal static class OpenTelemetryActivityExtensions
+{
+    private static class Messaging
+    {
+        public const string System = "kafka";
+        public const string DestinationKind = "topic";
+    }
+
+    private static class Operation
+    {
+        public const string Receive = "receive";
+        public const string Publish = "publish";
+    }
+
+    public static Activity AddDefaultOpenTelemetryTags(this Activity activity,
+        string topicName,
+        string messageId,
+        string clientId,
+        string partitionKey,
+        int? partition = null)
+    {
+        // handle null activity
+        if (activity == null)
+            return null;
+
+        // messaging tags
+        activity.SetTag(OpenTelemetryMessagingAttributes.SYSTEM, Messaging.System);
+        activity.SetTag(OpenTelemetryMessagingAttributes.DESTINATION_KIND, Messaging.DestinationKind);
+
+        activity.SetTag(OpenTelemetryMessagingAttributes.DESTINATION, topicName);
+        activity.SetTag(OpenTelemetryMessagingAttributes.MESSAGE_ID, messageId);
+        activity.SetTag(OpenTelemetryMessagingAttributes.CLIENT_ID, clientId);
+
+        // kafka specific tags
+        activity.SetTag(OpenTelemetryMessagingAttributes.KAFKA_MESSAGE_KEY, partitionKey);
+        if (partition.HasValue)
+            activity.SetTag(OpenTelemetryMessagingAttributes.KAFKA_PARTITION, partition);
+
+        return activity;
+    }
+
+    public static Activity AddConsumerOpenTelemetryTags(this Activity activity, string groupId)
+    {
+        if (activity == null)
+            return null;
+
+        activity.SetTag(OpenTelemetryMessagingAttributes.KAFKA_CONSUMER_GROUP, groupId);
+        activity.SetTag(OpenTelemetryMessagingAttributes.OPERATION, Operation.Receive);
+        return activity;
+    }
+
+    public static Activity AddProducerOpenTelemetryTags(this Activity activity)
+    {
+        if (activity == null)
+            return null;
+
+        activity.SetTag(OpenTelemetryMessagingAttributes.OPERATION, Operation.Publish);
+        return activity;
+    }
+}

--- a/src/Dafda/Diagnostics/OpenTelemetryMessagingAttributes.cs
+++ b/src/Dafda/Diagnostics/OpenTelemetryMessagingAttributes.cs
@@ -1,0 +1,58 @@
+namespace Dafda.Diagnostics;
+
+/// <summary>
+/// Provides the OpenTelemetry messaging attributes.
+/// The complete list of messaging attributes specification is available here: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/#messaging-attributes
+/// </summary>
+internal static class OpenTelemetryMessagingAttributes
+{
+    /// <summary>
+    /// Message system. For Kafka, attribute value must be "kafka".
+    /// </summary>
+    public const string SYSTEM = "messaging.system";
+
+    /// <summary>
+    /// Message destination. For Kafka, attribute value must be a Kafka topic.
+    /// </summary>
+    public const string DESTINATION = "messaging.destination";
+
+    /// <summary>
+    /// Destination kind. For Kafka, attribute value must be "topic".
+    /// </summary>
+    public const string DESTINATION_KIND = "messaging.destination_kind";
+
+    /// <summary>
+    /// A value used by the messaging system as an identifier for the message, represented as a string.
+    /// </summary>
+    public const string MESSAGE_ID = "messaging.message.id";
+
+    /// <summary>
+    /// A string identifying the kind of messaging operation
+    /// </summary>
+    public const string OPERATION = "messaging.operation";
+
+    /// <summary>
+    /// The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called “Correlation ID”.
+    /// </summary>
+    public const string CONVERSATION_ID = "messaging.message.conversation_id";
+
+    /// <summary>
+    /// A unique identifier for the client that consumes or produces a message.
+    /// </summary>
+    public const string CLIENT_ID = "messaging.client_id";
+
+    /// <summary>
+    /// Kafka partition number.
+    /// </summary>
+    public const string KAFKA_PARTITION = "messaging.kafka.destination.partition";
+
+    /// <summary>
+    /// Kafka message key.
+    /// </summary>
+    public const string KAFKA_MESSAGE_KEY = "messaging.kafka.message_key";
+
+    /// <summary>
+    /// Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers.
+    /// </summary>
+    public const string KAFKA_CONSUMER_GROUP = "messaging.kafka.consumer.group";
+}

--- a/src/Dafda/Diagnostics/OpenTelemetryMessagingAttributes.cs
+++ b/src/Dafda/Diagnostics/OpenTelemetryMessagingAttributes.cs
@@ -20,47 +20,47 @@ internal static class OpenTelemetryMessagingAttributes
     /// <summary>
     /// Message system. For Kafka, attribute value must be "kafka".
     /// </summary>
-    public const string SYSTEM = "messaging.system";
+    public const string System = "messaging.system";
 
     /// <summary>
     /// Message destination. For Kafka, attribute value must be a Kafka topic.
     /// </summary>
-    public const string DESTINATION = "messaging.destination";
+    public const string Destination = "messaging.destination";
 
     /// <summary>
     /// Destination kind. For Kafka, attribute value must be "topic".
     /// </summary>
-    public const string DESTINATION_KIND = "messaging.destination_kind";
+    public const string DestinationKind = "messaging.destination_kind";
 
     /// <summary>
     /// A value used by the messaging system as an identifier for the message, represented as a string.
     /// </summary>
-    public const string MESSAGE_ID = "messaging.message.id";
+    public const string MessageId = "messaging.message.id";
 
     /// <summary>
     /// A string identifying the kind of messaging operation
     /// </summary>
-    public const string OPERATION = "messaging.operation";
+    public const string Operation = "messaging.operation";
 
     /// <summary>
     /// A unique identifier for the client that consumes or produces a message.
     /// </summary>
-    public const string CLIENT_ID = "messaging.client_id";
+    public const string ClientId = "messaging.client_id";
 
     /// <summary>
     /// Kafka partition number.
     /// </summary>
-    public const string KAFKA_PARTITION = "messaging.kafka.destination.partition";
+    public const string KafkaPartition = "messaging.kafka.destination.partition";
 
     /// <summary>
     /// Kafka message key.
     /// </summary>
-    public const string KAFKA_MESSAGE_KEY = "messaging.kafka.message_key";
+    public const string KafkaMessageKey = "messaging.kafka.message_key";
 
     /// <summary>
     /// Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers.
     /// </summary>
-    public const string KAFKA_CONSUMER_GROUP = "messaging.kafka.consumer.group";
+    public const string KafkaConsumerGroup = "messaging.kafka.consumer.group";
 }
 
 internal static class ConsumerActivitySource

--- a/src/Dafda/Diagnostics/OpenTelemetryMessagingAttributes.cs
+++ b/src/Dafda/Diagnostics/OpenTelemetryMessagingAttributes.cs
@@ -1,3 +1,10 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using Dafda.Consuming;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+
 namespace Dafda.Diagnostics;
 
 /// <summary>
@@ -55,4 +62,92 @@ internal static class OpenTelemetryMessagingAttributes
     /// Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers.
     /// </summary>
     public const string KAFKA_CONSUMER_GROUP = "messaging.kafka.consumer.group";
+}
+
+internal static class OpenTelemetryActivityExtensions
+{
+    private static class Messaging
+    {
+        public const string System = "kafka";
+        public const string DestinationKind = "topic";
+    }
+
+    private static class Operation
+    {
+        public const string Receive = "receive";
+        public const string Publish = "publish";
+    }
+
+    public static Activity AddDefaultOpenTelemetryTags(this Activity activity,
+        string topicName,
+        string messageId,
+        string conversationId,
+        string clientId,
+        string partitionKey,
+        int partition)
+    {
+        // messaging tags
+        activity.SetTag(OpenTelemetryMessagingAttributes.SYSTEM, Messaging.System);
+        activity.SetTag(OpenTelemetryMessagingAttributes.DESTINATION_KIND, Messaging.DestinationKind);
+
+        activity.SetTag(OpenTelemetryMessagingAttributes.DESTINATION, topicName);
+        activity.SetTag(OpenTelemetryMessagingAttributes.MESSAGE_ID, messageId);
+        activity.SetTag(OpenTelemetryMessagingAttributes.CONVERSATION_ID, conversationId);
+        activity.SetTag(OpenTelemetryMessagingAttributes.CLIENT_ID, clientId);
+
+        // kafka specific tags
+        activity.SetTag(OpenTelemetryMessagingAttributes.KAFKA_MESSAGE_KEY, partitionKey);
+        activity.SetTag(OpenTelemetryMessagingAttributes.KAFKA_PARTITION, partition);
+
+        return activity;
+    }
+
+    public static Activity AddConsumerOpenTelemetryTags(this Activity activity, string groupId)
+    {
+        activity.SetTag(OpenTelemetryMessagingAttributes.KAFKA_CONSUMER_GROUP, groupId);
+        activity.SetTag(OpenTelemetryMessagingAttributes.OPERATION, Operation.Receive);
+        return activity;
+    }
+
+    public static Activity AddProducerOpenTelemetryTags(this Activity activity)
+    {
+        activity.SetTag(OpenTelemetryMessagingAttributes.OPERATION, Operation.Publish);
+        return activity;
+    }
+}
+
+internal static class ConsumerActivitySource
+{
+    private const string ActivityNameSuffix = "receive";
+
+    private static readonly AssemblyName AssemblyName = typeof(KafkaConsumerScope).Assembly.GetName();
+    private static readonly ActivitySource ActivitySource = new(AssemblyName.Name, AssemblyName.Version.ToString());
+    public static TextMapPropagator Propagator { get; set; } = Propagators.DefaultTextMapPropagator;
+
+    public static Activity StartActivity(MessageResult @event)
+    {
+        // Extract the context injected in the metadata by the publisher
+        var message = @event.Message;
+        var parentContext = Propagator.Extract(default, message.Metadata, ExtractFromMetadata);
+
+        // Inject extracted info into current context
+        Baggage.Current = parentContext.Baggage;
+
+        // Start the activity
+        return ActivitySource.StartActivity($"{@event.Topic} {ActivityNameSuffix}", ActivityKind.Consumer, parentContext.ActivityContext)
+            .AddDefaultOpenTelemetryTags(
+                topicName: @event.Topic,
+                messageId: @event.Message.Metadata.MessageId,
+                conversationId: @event.Message.Metadata.CorrelationId,
+                clientId: @event.ClientId,
+                partitionKey: @event.PartitionKey,
+                partition: @event.Partition)
+            .AddConsumerOpenTelemetryTags(
+                groupId: @event.GroupId);
+    }
+
+    private static IEnumerable<string> ExtractFromMetadata(Metadata metadata, string key)
+    {
+        yield return metadata[key];
+    }
 }

--- a/src/Dafda/Diagnostics/OpenTelemetryMessagingAttributes.cs
+++ b/src/Dafda/Diagnostics/OpenTelemetryMessagingAttributes.cs
@@ -1,5 +1,3 @@
-using Confluent.Kafka;
-
 namespace Dafda.Diagnostics;
 
 /// <summary>

--- a/src/Dafda/Diagnostics/ProducerActivitySource.cs
+++ b/src/Dafda/Diagnostics/ProducerActivitySource.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics;
+using System.Reflection;
+using Dafda.Producing;
+using Dafda.Serializing;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+
+namespace Dafda.Diagnostics;
+
+internal static class ProducerActivitySource
+{
+    private const string ActivityNameSuffix = "send";
+    private static readonly AssemblyName AssemblyName = typeof(KafkaProducer).Assembly.GetName();
+    private static readonly ActivitySource ActivitySource = new(AssemblyName.Name, AssemblyName.Version.ToString());
+    public static TextMapPropagator Propagator { get; set; } = Propagators.DefaultTextMapPropagator;
+
+    public static Activity StartActivity(PayloadDescriptor payloadDescriptor)
+    {
+        // Extract the current activity context
+        var contextToInject = Activity.Current?.Context
+                              ?? default;
+
+        // Inject the current context into the message headers
+        Propagator.Inject(new PropagationContext(contextToInject, Baggage.Current), payloadDescriptor, InjectTraceContext);
+
+        // Start the activity
+        return ActivitySource.StartActivity($"{payloadDescriptor.TopicName} {ActivityNameSuffix}", ActivityKind.Producer)
+            .AddDefaultOpenTelemetryTags(
+                topicName: payloadDescriptor.TopicName,
+                messageId: payloadDescriptor.MessageId,
+                clientId: payloadDescriptor.ClientId,
+                partitionKey: payloadDescriptor.PartitionKey)
+            .AddProducerOpenTelemetryTags();
+    }
+
+    private static void InjectTraceContext(PayloadDescriptor descriptor, string key, string value)
+    {
+        descriptor.AddHeader(key, value);
+    }
+}

--- a/src/Dafda/Producing/KafkaProducer.cs
+++ b/src/Dafda/Producing/KafkaProducer.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Confluent.Kafka;
-using Dafda.Consuming;
-using Dafda.Diagnostics;
 using Dafda.Serializing;
 using Microsoft.Extensions.Logging;
 

--- a/src/Dafda/Producing/KafkaProducer.cs
+++ b/src/Dafda/Producing/KafkaProducer.cs
@@ -28,6 +28,8 @@ namespace Dafda.Producing
         {
             using var activity = DafdaActivitySource.ActivitySource.StartActivity($"{payloadDescriptor.TopicName} send", ActivityKind.Producer);
 
+            _logger.LogDebug("Starting new activity Producer:{ParentActivityId}:{ActivityId}", activity?.ParentId, activity?.Id);
+
             var serializer = _payloadSerializerRegistry.Get(payloadDescriptor.TopicName);
             
             await InternalProduce(

--- a/src/Dafda/Producing/KafkaProducer.cs
+++ b/src/Dafda/Producing/KafkaProducer.cs
@@ -26,12 +26,13 @@ namespace Dafda.Producing
 
         public async Task Produce(PayloadDescriptor payloadDescriptor)
         {
-            using var activity = DafdaActivitySource.ActivitySource.StartActivity($"{payloadDescriptor.TopicName} send", ActivityKind.Producer);
+            // TODO: Add activity source
+            // using var activity = DafdaActivitySource.ActivitySource.StartActivity($"{payloadDescriptor.TopicName} send", ActivityKind.Producer);
 
-            _logger.LogDebug("Starting new activity Producer:{ParentActivityId}:{ActivityId}", activity?.ParentId, activity?.Id);
+            // _logger.LogDebug("Starting new activity Producer:{ParentActivityId}:{ActivityId}", activity?.ParentId, activity?.Id);
 
             var serializer = _payloadSerializerRegistry.Get(payloadDescriptor.TopicName);
-            
+
             await InternalProduce(
                 topic: payloadDescriptor.TopicName,
                 key: payloadDescriptor.PartitionKey,

--- a/src/Dafda/Producing/KafkaProducer.cs
+++ b/src/Dafda/Producing/KafkaProducer.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Confluent.Kafka;
 using Dafda.Consuming;
+using Dafda.Diagnostics;
 using Dafda.Serializing;
 using Microsoft.Extensions.Logging;
 
@@ -26,11 +27,6 @@ namespace Dafda.Producing
 
         public async Task Produce(PayloadDescriptor payloadDescriptor)
         {
-            // TODO: Add activity source
-            // using var activity = DafdaActivitySource.ActivitySource.StartActivity($"{payloadDescriptor.TopicName} send", ActivityKind.Producer);
-
-            // _logger.LogDebug("Starting new activity Producer:{ParentActivityId}:{ActivityId}", activity?.ParentId, activity?.Id);
-
             var serializer = _payloadSerializerRegistry.Get(payloadDescriptor.TopicName);
 
             await InternalProduce(
@@ -51,7 +47,7 @@ namespace Dafda.Producing
                     message: new Message<string, string>
                     {
                         Key = key,
-                        Value = value
+                        Value = value,
                     }
                 );
             }

--- a/src/Dafda/Producing/KafkaProducer.cs
+++ b/src/Dafda/Producing/KafkaProducer.cs
@@ -22,6 +22,8 @@ namespace Dafda.Producing
             _innerKafkaProducer = new ProducerBuilder<string, string>(configuration).Build();
         }
 
+        public string ClientId => _innerKafkaProducer.Name;
+
         public async Task Produce(PayloadDescriptor payloadDescriptor)
         {
             using var activity = DafdaActivitySource.ActivitySource.StartActivity($"{payloadDescriptor.TopicName} send", ActivityKind.Producer);

--- a/src/Dafda/Producing/KafkaProducer.cs
+++ b/src/Dafda/Producing/KafkaProducer.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Confluent.Kafka;
+using Dafda.Consuming;
 using Dafda.Serializing;
 using Microsoft.Extensions.Logging;
 
@@ -22,6 +24,8 @@ namespace Dafda.Producing
 
         public async Task Produce(PayloadDescriptor payloadDescriptor)
         {
+            using var activity = DafdaActivitySource.ActivitySource.StartActivity($"{payloadDescriptor.TopicName} send", ActivityKind.Producer);
+
             var serializer = _payloadSerializerRegistry.Get(payloadDescriptor.TopicName);
             
             await InternalProduce(

--- a/src/Dafda/Producing/Producer.cs
+++ b/src/Dafda/Producing/Producer.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Dafda.Consuming;
 using Dafda.Diagnostics;
 
@@ -41,7 +40,7 @@ namespace Dafda.Producing
         {
             var payloadDescriptor = _payloadDescriptorFactory.Create(message, headers);
             payloadDescriptor.ClientId = _kafkaProducer.ClientId;
-            
+
             using var activity = ProducerActivitySource.StartActivity(payloadDescriptor);
 
             await _kafkaProducer.Produce(payloadDescriptor);

--- a/src/Dafda/Producing/Producer.cs
+++ b/src/Dafda/Producing/Producer.cs
@@ -38,6 +38,8 @@ namespace Dafda.Producing
         public async Task Produce(object message, Metadata headers)
         {
             var payloadDescriptor = _payloadDescriptorFactory.Create(message, headers);
+            payloadDescriptor.ClientId = _kafkaProducer.ClientId;
+
             await _kafkaProducer.Produce(payloadDescriptor);
         }
 
@@ -71,6 +73,8 @@ namespace Dafda.Producing
         public async Task Produce(object message, MessageHandlerContext context, Dictionary<string, string> headers)
         {
             var payloadDescriptor = _payloadDescriptorFactory.Create(message, context, headers);
+            payloadDescriptor.ClientId = _kafkaProducer.ClientId;
+
             await _kafkaProducer.Produce(payloadDescriptor);
         }
     }

--- a/src/Dafda/Producing/Producer.cs
+++ b/src/Dafda/Producing/Producer.cs
@@ -1,7 +1,9 @@
 ﻿using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Dafda.Consuming;
+using Dafda.Diagnostics;
 
 namespace Dafda.Producing
 {
@@ -20,7 +22,7 @@ namespace Dafda.Producing
         }
 
         internal string Name { get; set; } = "__Default Producer__";
-        
+
         /// <summary>
         /// Produce a <paramref name="message"/> on Kafka
         /// </summary>
@@ -39,6 +41,8 @@ namespace Dafda.Producing
         {
             var payloadDescriptor = _payloadDescriptorFactory.Create(message, headers);
             payloadDescriptor.ClientId = _kafkaProducer.ClientId;
+            
+            using var activity = ProducerActivitySource.StartActivity(payloadDescriptor);
 
             await _kafkaProducer.Produce(payloadDescriptor);
         }

--- a/src/Dafda/Serializing/DefaultPayloadSerializer.cs
+++ b/src/Dafda/Serializing/DefaultPayloadSerializer.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
-using OpenTelemetry;
-using OpenTelemetry.Context.Propagation;
 
 namespace Dafda.Serializing
 {

--- a/src/Dafda/Serializing/DefaultPayloadSerializer.cs
+++ b/src/Dafda/Serializing/DefaultPayloadSerializer.cs
@@ -45,7 +45,7 @@ namespace Dafda.Serializing
 
         private object ConvertToMessagePayload(PayloadDescriptor descriptor)
         {
-            // NOTE: due to a bug in system.text.json an additional conversion 
+            // NOTE: due to a bug in system.text.json an additional conversion
             // is made to have proper dictionary key casing - on envelope keys only though!
             // For reference: https://github.com/dotnet/runtime/issues/31849
 
@@ -72,35 +72,9 @@ namespace Dafda.Serializing
                 envelope.Add(MakeKeyFrom(key), value);
             }
 
-            ActivityContext context = default;
-            Activity activity = Activity.Current;
-            if (activity != null)
-            {
-                context = activity.Context;
-            }
-
-            Propagator.Inject(new PropagationContext(context, Baggage.Current), envelope, InjectMetadata);
-
-            activity?.SetTag("messaging.system", "kafka");
-            activity?.SetTag("messaging.destination", descriptor.TopicName);
-            activity?.SetTag("messaging.destination_kind", "topic");
-            activity?.SetTag("messaging.message_id", descriptor.MessageId);
-            //activity?.SetTag("messaging.message_payload_size_bytes", "0");
-            // kafka
-            activity?.SetTag("messaging.kafka.message_key", descriptor.PartitionKey);
-            activity?.SetTag("messaging.kafka.client_id", descriptor.ClientId);
-
             envelope.Add(MakeKeyFrom("Data"), descriptor.MessageData);
 
             return envelope;
         }
-
-        private static void InjectMetadata(Dictionary<string, object> headers, string key, string value)
-        {
-            headers[key] = value;
-        }
-
-
-        internal static TextMapPropagator Propagator { get; set; }= Propagators.DefaultTextMapPropagator;
     }
 }

--- a/src/Dafda/Serializing/DefaultPayloadSerializer.cs
+++ b/src/Dafda/Serializing/DefaultPayloadSerializer.cs
@@ -85,14 +85,10 @@ namespace Dafda.Serializing
             activity?.SetTag("messaging.destination", descriptor.TopicName);
             activity?.SetTag("messaging.destination_kind", "topic");
             activity?.SetTag("messaging.message_id", descriptor.MessageId);
-            //activity?.SetTag("messaging.conversation_id", descriptor.CorrelationId);
             //activity?.SetTag("messaging.message_payload_size_bytes", "0");
-            // consumer
             // kafka
             activity?.SetTag("messaging.kafka.message_key", descriptor.PartitionKey);
-            //activity?.SetTag("messaging.kafka.consumer_group", "consumer_group");
-            //activity?.SetTag("messaging.kafka.client_id", "client_id");
-            //activity?.SetTag("messaging.kafka.partition", "partition");
+            activity?.SetTag("messaging.kafka.client_id", descriptor.ClientId);
 
             envelope.Add(MakeKeyFrom("Data"), descriptor.MessageData);
 

--- a/src/Dafda/Serializing/DefaultPayloadSerializer.cs
+++ b/src/Dafda/Serializing/DefaultPayloadSerializer.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
 
 namespace Dafda.Serializing
 {
@@ -69,9 +72,39 @@ namespace Dafda.Serializing
                 envelope.Add(MakeKeyFrom(key), value);
             }
 
+            ActivityContext context = default;
+            Activity activity = Activity.Current;
+            if (activity != null)
+            {
+                context = activity.Context;
+            }
+
+            Propagator.Inject(new PropagationContext(context, Baggage.Current), envelope, InjectMetadata);
+
+            activity?.SetTag("messaging.system", "kafka");
+            activity?.SetTag("messaging.destination", descriptor.TopicName);
+            activity?.SetTag("messaging.destination_kind", "topic");
+            activity?.SetTag("messaging.message_id", descriptor.MessageId);
+            //activity?.SetTag("messaging.conversation_id", descriptor.CorrelationId);
+            //activity?.SetTag("messaging.message_payload_size_bytes", "0");
+            // consumer
+            // kafka
+            activity?.SetTag("messaging.kafka.message_key", descriptor.PartitionKey);
+            //activity?.SetTag("messaging.kafka.consumer_group", "consumer_group");
+            //activity?.SetTag("messaging.kafka.client_id", "client_id");
+            //activity?.SetTag("messaging.kafka.partition", "partition");
+
             envelope.Add(MakeKeyFrom("Data"), descriptor.MessageData);
 
             return envelope;
         }
+
+        private static void InjectMetadata(Dictionary<string, object> headers, string key, string value)
+        {
+            headers[key] = value;
+        }
+
+
+        internal static TextMapPropagator Propagator { get; set; }= Propagators.DefaultTextMapPropagator;
     }
 }

--- a/src/Dafda/Serializing/PayloadDescriptor.cs
+++ b/src/Dafda/Serializing/PayloadDescriptor.cs
@@ -57,5 +57,7 @@ namespace Dafda.Serializing
         /// The message
         /// </summary>
         public object MessageData { get; private set; }
+
+        internal string ClientId { get; set; }
     }
 }

--- a/src/Dafda/Serializing/PayloadDescriptor.cs
+++ b/src/Dafda/Serializing/PayloadDescriptor.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Dafda.Serializing
 {
@@ -9,6 +10,9 @@ namespace Dafda.Serializing
     /// </summary>
     public sealed class PayloadDescriptor
     {
+
+        private readonly IDictionary<string, string> _headers;
+
         /// <summary>
         /// Initialize an instance of the <see cref="PayloadDescriptor"/>
         /// </summary>
@@ -25,7 +29,8 @@ namespace Dafda.Serializing
             PartitionKey = partitionKey;
             MessageType = messageType;
             MessageData = messageData;
-            MessageHeaders = messageHeaders;
+
+            _headers = messageHeaders.ToDictionary(kv => kv.Key, kv => kv.Value);
         }
 
         /// <summary>
@@ -51,7 +56,9 @@ namespace Dafda.Serializing
         /// <summary>
         /// The list of headers
         /// </summary>
-        public IEnumerable<KeyValuePair<string, string>> MessageHeaders { get; private set; }
+        public IEnumerable<KeyValuePair<string, string>> MessageHeaders => _headers
+            .ToList()
+            .AsReadOnly();
 
         /// <summary>
         /// The message
@@ -59,5 +66,10 @@ namespace Dafda.Serializing
         public object MessageData { get; private set; }
 
         internal string ClientId { get; set; }
+
+        internal void AddHeader(string key, string value)
+        {
+            _headers[key] = value;
+        }
     }
 }

--- a/tester/Tester/Program.cs
+++ b/tester/Tester/Program.cs
@@ -6,6 +6,9 @@ using Dafda.Consuming;
 using Dafda.Producing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 
 namespace Tester
 {
@@ -13,6 +16,16 @@ namespace Tester
     {
         public static async Task Main(string[] args)
         {
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("Tester"))
+                .AddSource("Dafda")
+                .AddConsoleExporter()
+                .AddOtlpExporter(options =>
+                {
+                    options.Endpoint = new Uri("http://localhost:4317");
+                })
+                .Build();
+
             var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             await CreateHostBuilder(args).Build().RunAsync(tokenSource.Token);
         }

--- a/tester/Tester/Tester.csproj
+++ b/tester/Tester/Tester.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dafda" Version="0.11.2-beta-1" />
+    <PackageReference Include="Dafda" Version="0.12.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
   </ItemGroup>
 
 </Project>

--- a/tester/Tester/Tester.csproj
+++ b/tester/Tester/Tester.csproj
@@ -7,8 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dafda" Version="0.10.0" />
+    <PackageReference Include="Dafda" Version="0.11.2-beta-1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0-rc3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds OpenTelemetry Tracing as discsussed in #50.

Includes: 
 - refactored the dead branch (v0.12.0-otel1) and aligned it with newest [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/#messaging-attributes).
- The tracing context between consumer and producer propagates via a new `traceparent` message header on the envelope. This is aligned with a  [W3C Trace Context spec](https://www.w3.org/TR/trace-context/#relationship-between-the-headers).
- some minor linting (e.g. removing references of unused namespaces)