### PR TITLE
Upgrade CodeQL GitHub actions to version 3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
@@ -43,4 +43,4 @@ jobs:
       run: dotnet build --no-restore src\
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Upgrade CodeQL GitHub actions to version 3
- As version 1 is deprecated, it should be updated to a supported version.

See https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/ for more information.