### PR TITLE
Update Confluent.Kafka library to version 2.3.0

### DIFF
--- a/src/Dafda/Dafda.csproj
+++ b/src/Dafda/Dafda.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="2.0.2" />
+    <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.7.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />


### PR DESCRIPTION
Includes enhancements and fixes since 2.0.2 and a reference to librdkafka 2.3.0.

For details see:

- Version referenced: https://github.com/confluentinc/confluent-kafka-dotnet/releases/tag/v2.3.0
- Changes from 2.0.2-2.3.0:
  - Releases: https://github.com/confluentinc/confluent-kafka-dotnet/releases
  - Full changelog: https://github.com/confluentinc/confluent-kafka-dotnet/compare/v2.2.0...v2.3.0