### PR TITLE
Bufgix/producing traceparent propagation

### DIFF
--- a/src/Dafda.Tests/Configuration/TestConsumerServiceCollectionExtensions.cs
+++ b/src/Dafda.Tests/Configuration/TestConsumerServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ using Xunit;
 
 namespace Dafda.Tests.Configuration
 {
+    [Collection("Serializing")]
     public class TestConsumerServiceCollectionExtensions
     {
         [Fact( /*Skip = "is this relevant for testing these extensions"*/)]

--- a/src/Dafda.Tests/Producing/TestOutgoingMessageFactory.cs
+++ b/src/Dafda.Tests/Producing/TestOutgoingMessageFactory.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace Dafda.Tests.Producing
 {
+    [Collection("Serializing")]
     public class TestOutgoingMessageFactory
     {
         private const string DummyTopic = "dummy_topic";

--- a/src/Dafda.Tests/Producing/TestProducer.cs
+++ b/src/Dafda.Tests/Producing/TestProducer.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Dafda.Tests.Producing
 {
+    [Collection("Serializing")]
     public class TestProducer
     {
         [Fact]
@@ -250,6 +251,7 @@ namespace Dafda.Tests.Producing
             AssertJson.Equal(expected, spy.Value);
         }
 
+        //[Fact(Skip = "This test has a static dependency that might break other tests")]
         [Fact]
         public async Task produces_message_with_traceparent_and_baggage_propagation_in_header()
         {

--- a/src/Dafda.Tests/TestDoubles/KafkaProducerSpy.cs
+++ b/src/Dafda.Tests/TestDoubles/KafkaProducerSpy.cs
@@ -30,7 +30,7 @@ namespace Dafda.Tests.TestDoubles
             Topic = topic;
             Key = key;
             Value = value;
-            ProducerActivityId = Activity.Current?.Parent?.Id;
+            ProducerActivityId = Activity.Current?.Id;
 
             return Task.CompletedTask;
         }

--- a/src/Dafda/Dafda.csproj
+++ b/src/Dafda/Dafda.csproj
@@ -7,7 +7,7 @@
     <Description>A small client for Kafka</Description>
     <RepositoryUrl>https://github.com/dfds/dafda</RepositoryUrl>
     <PackageProjectUrl>https://github.com/dfds/dafda</PackageProjectUrl>
-    <Version>0.12.0</Version>
+    <Version>0.12.1</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/Dafda/Dafda.csproj
+++ b/src/Dafda/Dafda.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.8.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
 
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />

--- a/src/Dafda/Diagnostics/ConsumerActivitySource.cs
+++ b/src/Dafda/Diagnostics/ConsumerActivitySource.cs
@@ -25,7 +25,7 @@ internal static class ConsumerActivitySource
         Baggage.Current = parentContext.Baggage;
 
         // Start the activity
-        return ActivitySource.StartActivity($"{@event.Topic} {ActivityNameSuffix}", ActivityKind.Consumer, parentContext.ActivityContext)
+        return ActivitySource.StartActivity($"{@event.Topic} {@event.Message.Metadata.Type} {ActivityNameSuffix}", ActivityKind.Consumer, parentContext.ActivityContext)
             .AddDefaultOpenTelemetryTags(
                 destinationName: @event.Topic,
                 messageId: @event.Message.Metadata.MessageId,

--- a/src/Dafda/Diagnostics/ConsumerActivitySource.cs
+++ b/src/Dafda/Diagnostics/ConsumerActivitySource.cs
@@ -27,7 +27,7 @@ internal static class ConsumerActivitySource
         // Start the activity
         return ActivitySource.StartActivity($"{@event.Topic} {ActivityNameSuffix}", ActivityKind.Consumer, parentContext.ActivityContext)
             .AddDefaultOpenTelemetryTags(
-                topicName: @event.Topic,
+                destinationName: @event.Topic,
                 messageId: @event.Message.Metadata.MessageId,
                 clientId: @event.ClientId,
                 partitionKey: @event.PartitionKey,

--- a/src/Dafda/Diagnostics/OpenTelemetryActivityExtensions.cs
+++ b/src/Dafda/Diagnostics/OpenTelemetryActivityExtensions.cs
@@ -7,7 +7,6 @@ internal static class OpenTelemetryActivityExtensions
     private static class Messaging
     {
         public const string System = "kafka";
-        public const string DestinationKind = "topic";
     }
 
     private static class Operation
@@ -17,7 +16,7 @@ internal static class OpenTelemetryActivityExtensions
     }
 
     public static Activity AddDefaultOpenTelemetryTags(this Activity activity,
-        string topicName,
+        string destinationName,
         string messageId,
         string clientId,
         string partitionKey,
@@ -29,16 +28,14 @@ internal static class OpenTelemetryActivityExtensions
 
         // messaging tags
         activity.SetTag(OpenTelemetryMessagingAttributes.System, Messaging.System);
-        activity.SetTag(OpenTelemetryMessagingAttributes.DestinationKind, Messaging.DestinationKind);
-
-        activity.SetTag(OpenTelemetryMessagingAttributes.Destination, topicName);
+        activity.SetTag(OpenTelemetryMessagingAttributes.DestinationName, destinationName);
         activity.SetTag(OpenTelemetryMessagingAttributes.MessageId, messageId);
         activity.SetTag(OpenTelemetryMessagingAttributes.ClientId, clientId);
 
         // kafka specific tags
-        activity.SetTag(OpenTelemetryMessagingAttributes.KafkaMessageKey, partitionKey);
+        activity.SetTag(OpenTelemetryMessagingAttributes.Kafka.MessageKey, partitionKey);
         if (partition.HasValue)
-            activity.SetTag(OpenTelemetryMessagingAttributes.KafkaPartition, partition);
+            activity.SetTag(OpenTelemetryMessagingAttributes.Kafka.Partition, partition);
 
         return activity;
     }
@@ -48,7 +45,7 @@ internal static class OpenTelemetryActivityExtensions
         if (activity == null)
             return null;
 
-        activity.SetTag(OpenTelemetryMessagingAttributes.KafkaConsumerGroup, groupId);
+        activity.SetTag(OpenTelemetryMessagingAttributes.Kafka.ConsumerGroup, groupId);
         activity.SetTag(OpenTelemetryMessagingAttributes.Operation, Operation.Receive);
         return activity;
     }

--- a/src/Dafda/Diagnostics/OpenTelemetryMessagingAttributes.cs
+++ b/src/Dafda/Diagnostics/OpenTelemetryMessagingAttributes.cs
@@ -12,21 +12,6 @@ internal static class OpenTelemetryMessagingAttributes
     public const string System = "messaging.system";
 
     /// <summary>
-    /// Message destination. For Kafka, attribute value must be a Kafka topic.
-    /// </summary>
-    public const string Destination = "messaging.destination";
-
-    /// <summary>
-    /// Destination kind. For Kafka, attribute value must be "topic".
-    /// </summary>
-    public const string DestinationKind = "messaging.destination_kind";
-
-    /// <summary>
-    /// A value used by the messaging system as an identifier for the message, represented as a string.
-    /// </summary>
-    public const string MessageId = "messaging.message.id";
-
-    /// <summary>
     /// A string identifying the kind of messaging operation
     /// </summary>
     public const string Operation = "messaging.operation";
@@ -37,17 +22,33 @@ internal static class OpenTelemetryMessagingAttributes
     public const string ClientId = "messaging.client_id";
 
     /// <summary>
-    /// Kafka partition number.
+    /// A value used by the messaging system as an identifier for the message, represented as a string.
     /// </summary>
-    public const string KafkaPartition = "messaging.kafka.destination.partition";
+    public const string MessageId = "messaging.message.id";
 
     /// <summary>
-    /// Kafka message key.
+    /// Message destination. For Kafka, attribute value must be a Kafka topic.
     /// </summary>
-    public const string KafkaMessageKey = "messaging.kafka.message_key";
+    public const string DestinationName = "messaging.destination.name";
 
     /// <summary>
-    /// Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers.
+    /// Kafka specific attributes.
     /// </summary>
-    public const string KafkaConsumerGroup = "messaging.kafka.consumer.group";
+    internal static class Kafka
+    {
+        /// <summary>
+        /// Partition (int) the message is sent to.
+        /// </summary>
+        public const string Partition = "messaging.kafka.destination.partition";
+
+        /// <summary>
+        /// Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers.
+        /// </summary>
+        public const string ConsumerGroup = "messaging.kafka.consumer.group";
+
+        /// <summary>
+        /// Kafka message key. Message keys in Kafka are used for grouping alike messages to ensure they’re processed on the same partition. They differ from messaging.message.id in that they’re not unique
+        /// </summary>
+        public const string MessageKey = "messaging.kafka.message.key";
+    }
 }

--- a/src/Dafda/Diagnostics/ProducerActivitySource.cs
+++ b/src/Dafda/Diagnostics/ProducerActivitySource.cs
@@ -26,7 +26,7 @@ internal static class ProducerActivitySource
         // Start the activity
         return ActivitySource.StartActivity($"{payloadDescriptor.TopicName} {ActivityNameSuffix}", ActivityKind.Producer)
             .AddDefaultOpenTelemetryTags(
-                topicName: payloadDescriptor.TopicName,
+                destinationName: payloadDescriptor.TopicName,
                 messageId: payloadDescriptor.MessageId,
                 clientId: payloadDescriptor.ClientId,
                 partitionKey: payloadDescriptor.PartitionKey)

--- a/src/Dafda/Diagnostics/ProducerActivitySource.cs
+++ b/src/Dafda/Diagnostics/ProducerActivitySource.cs
@@ -23,8 +23,9 @@ internal static class ProducerActivitySource
         // Inject the current context into the message headers
         Propagator.Inject(new PropagationContext(contextToInject, Baggage.Current), payloadDescriptor, InjectTraceContext);
 
+
         // Start the activity
-        return ActivitySource.StartActivity($"{payloadDescriptor.TopicName} {ActivityNameSuffix}", ActivityKind.Producer)
+        return ActivitySource.StartActivity($"{payloadDescriptor.TopicName} {payloadDescriptor.MessageType} {ActivityNameSuffix}", ActivityKind.Producer)
             .AddDefaultOpenTelemetryTags(
                 destinationName: payloadDescriptor.TopicName,
                 messageId: payloadDescriptor.MessageId,


### PR DESCRIPTION
The way how `Traceparent` header was built had an issue such that the started activity/span id was not included. This PR fixed that, among others:
- activity names include message type names (this way, it is possible to group activities uniquely per message type)
- OpenTelemetry.Api nuget version upgraded to v1.8
- kafka-specific activity tags were encapsulated into its own class
- Messaging attributes are updated to reflect the [current spec](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/):
  - `messaging.destination_kind` was dropped
  - `messaging.destination` was changed to `messaging.destination.name`
 