### PR TITLE
Add distributed tracing instrumentation to Outbox Producer

### DIFF
--- a/src/Dafda/Outbox/OutboxEntry.cs
+++ b/src/Dafda/Outbox/OutboxEntry.cs
@@ -53,7 +53,7 @@ namespace Dafda.Outbox
         /// <summary>
         /// The serialized payload
         /// </summary>
-        public string Payload { get; private set; }
+        public string Payload { get; internal set; }
 
         /// <summary>
         /// UTC datetime of when the message was generated

--- a/src/Dafda/Producing/OutboxProducer.cs
+++ b/src/Dafda/Producing/OutboxProducer.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Dafda.Diagnostics;
 using Dafda.Outbox;
 
 namespace Dafda.Producing
@@ -21,6 +24,8 @@ namespace Dafda.Producing
         /// <param name="entry">The outbox message</param>
         public async Task Produce(OutboxEntry entry)
         {
+            using var activity = DafdaActivitySource.StartPublishingActivity(entry, _kafkaProducer.ClientId);
+
             await _kafkaProducer.InternalProduce(entry.Topic, entry.Key, entry.Payload);
         }
     }


### PR DESCRIPTION
This change adds a publishing activity for producing outbox entries. 

Currently, it is geared towards messages that are serialised into json (e.g. dafda envelope and default .net json serializer).
The code assumes it is a dictionary-like string and stops if that is not a case.

What is happening:
1. serialise payload into dictionary, or stop if this fails
2. try to extract the parent activity
3. start a new activity, (and link with parent if it exists)
4. update the payload with the latest trace 