### PR TITLE
Bugfix/outbox producer serialization

### DIFF
--- a/src/Dafda.Tests/Outbox/TestProducer.cs
+++ b/src/Dafda.Tests/Outbox/TestProducer.cs
@@ -35,9 +35,9 @@ public class TestProducer
         Assert.Equal("1b13a5e1-742e-45fb-ab7a-76d547e4e327", payloadDictionary["correlationId"]);
 
         // Deserialize the data field to ensure it's a JSON object
-        var dataObject = JObject.Parse(payloadDictionary["data"]);
+        var dataObject = JObject.Parse(payloadDictionary["data"].ToString());
         Assert.Equal("8cfb2d2d-9113-48c8-8c8d-41ade8d79989", dataObject["dfdsUserId"]);
-        Assert.Equal("{\"dfdsUserId\":\"8cfb2d2d-9113-48c8-8c8d-41ade8d79989\"}", payloadDictionary["data"]);
+        Assert.Equal("{\"dfdsUserId\":\"8cfb2d2d-9113-48c8-8c8d-41ade8d79989\"}", payloadDictionary["data"].ToString());
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public class TestProducer
         Assert.Equal("AssociateAccessRelationsChanged", payloadDictionary["type"]);
 
         // Deserialize the data field to ensure it's a JSON object
-        var dataObject = JObject.Parse(payloadDictionary["data"]);
+        var dataObject = JObject.Parse(payloadDictionary["data"].ToString());
         Assert.Equal(22937, dataObject["freightPayerId"]);
         Assert.Equal("b3bef642-e347-417c-9bec-2660f4376ggg", dataObject["changedBy"]);
         Assert.Equal(2, dataObject["externalAssociates"].Count());

--- a/src/Dafda.Tests/Outbox/TestProducer.cs
+++ b/src/Dafda.Tests/Outbox/TestProducer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Dafda.Diagnostics;
 using Dafda.Outbox;
@@ -20,7 +21,7 @@ public class TestProducer
     {
         // Arrange
         string payload =
-            "{\"messageId\":\"1b13a5e1-742e-45fb-ab7a-76d547e4e327\",\"type\":\"userdisabled\",\"traceparent\":\"00-1f2c12212e50621b49c80175a064d193-35a6133087d5e877-01\",\"causationId\":\"1b13a5e1-742e-45fb-ab7a-76d547e4e327\",\"correlationId\":\"1b13a5e1-742e-45fb-ab7a-76d547e4e327\",\"data\":{\"dfdsUserId\":\"8cfb2d2d-9113-48c8-8c8d-41ade8d7998a\"}}";
+            "{\"messageId\":\"1b13a5e1-742e-45fb-ab7a-76d547e4e327\",\"type\":\"userdisabled\",\"traceparent\":\"00-1f2c12212e50621b49c80175a064d193-35a6133087d5e877-01\",\"causationId\":\"1b13a5e1-742e-45fb-ab7a-76d547e4e327\",\"correlationId\":\"1b13a5e1-742e-45fb-ab7a-76d547e4e327\",\"data\":{\"dfdsUserId\":\"8cfb2d2d-9113-48c8-8c8d-41ade8d79989\"}}";
         // Act
         bool result = DafdaActivitySource.TryDeserializePayload(payload, out var payloadDictionary);
 
@@ -32,7 +33,38 @@ public class TestProducer
         Assert.Equal("00-1f2c12212e50621b49c80175a064d193-35a6133087d5e877-01", payloadDictionary["traceparent"]);
         Assert.Equal("1b13a5e1-742e-45fb-ab7a-76d547e4e327", payloadDictionary["causationId"]);
         Assert.Equal("1b13a5e1-742e-45fb-ab7a-76d547e4e327", payloadDictionary["correlationId"]);
-        Assert.Equal("{\"dfdsUserId\":\"8cfb2d2d-9113-48c8-8c8d-41ade8d7998a\"}", payloadDictionary["data"]);
+
+        // Deserialize the data field to ensure it's a JSON object
+        var dataObject = JObject.Parse(payloadDictionary["data"]);
+        Assert.Equal("8cfb2d2d-9113-48c8-8c8d-41ade8d79989", dataObject["dfdsUserId"]);
+        Assert.Equal("{\"dfdsUserId\":\"8cfb2d2d-9113-48c8-8c8d-41ade8d79989\"}", payloadDictionary["data"]);
+    }
+
+    [Fact]
+    public void TryDeserializePayload_should_deserialize_complex_json_string_to_dictionary()
+    {
+        // Arrange
+        string payload =
+            "{\"messageId\":\"0b8db195-62bd-43ee-9123-70b64adf9fff\",\"type\":\"AssociateAccessRelationsChanged\",\"data\":{\"freightPayerId\":22937,\"externalAssociates\":[{\"associateId\":75900,\"accessToFreightPayer\":1},{\"associateId\":51147,\"accessToFreightPayer\":1}],\"changedBy\":\"b3bef642-e347-417c-9bec-2660f4376ggg\"},\"correlationId\":null,\"causationId\":\"fecb6bee0a799cbd\",\"tenantId\":\"Production\"}";
+
+        // Act
+        bool result = DafdaActivitySource.TryDeserializePayload(payload, out var payloadDictionary);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(payloadDictionary);
+        Assert.Equal("0b8db195-62bd-43ee-9123-70b64adf9fff", payloadDictionary["messageId"]);
+        Assert.Equal("AssociateAccessRelationsChanged", payloadDictionary["type"]);
+
+        // Deserialize the data field to ensure it's a JSON object
+        var dataObject = JObject.Parse(payloadDictionary["data"]);
+        Assert.Equal(22937, dataObject["freightPayerId"]);
+        Assert.Equal("b3bef642-e347-417c-9bec-2660f4376ggg", dataObject["changedBy"]);
+        Assert.Equal(2, dataObject["externalAssociates"].Count());
+
+        //Assert.Empty(payloadDictionary["correlationId"]);
+        Assert.Equal("fecb6bee0a799cbd", payloadDictionary["causationId"]);
+        Assert.Equal("Production", payloadDictionary["tenantId"]);
     }
 
     [Fact]
@@ -94,5 +126,13 @@ public class TestProducer
         var jsonObject = JObject.Parse(spy.Value);
         Assert.True(jsonObject["traceparent"] != null, "The JSON does not contain the traceparent element.");
         Assert.Contains(activities, a => a.DisplayName == $"{OpenTelemetryMessagingOperation.Producer.Publish} {topic} {type}");
+
+        // Deserialize the data field to ensure it's a JSON object
+        var dataObject = JObject.Parse(jsonObject["data"].ToString());
+        Assert.Equal("dummyId", dataObject["id"]);
+        
+        // Check that the serialized JSON does not contain unwanted escaped characters
+        Assert.DoesNotContain("\\u0022", spy.Value);
+        Assert.DoesNotContain("\\", spy.Value);
     }
 }

--- a/src/Dafda/Dafda.csproj
+++ b/src/Dafda/Dafda.csproj
@@ -7,7 +7,7 @@
     <Description>A small client for Kafka</Description>
     <RepositoryUrl>https://github.com/dfds/dafda</RepositoryUrl>
     <PackageProjectUrl>https://github.com/dfds/dafda</PackageProjectUrl>
-    <Version>0.12.2</Version>
+    <Version>0.12.4</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/Dafda/Dafda.csproj
+++ b/src/Dafda/Dafda.csproj
@@ -7,7 +7,7 @@
     <Description>A small client for Kafka</Description>
     <RepositoryUrl>https://github.com/dfds/dafda</RepositoryUrl>
     <PackageProjectUrl>https://github.com/dfds/dafda</PackageProjectUrl>
-    <Version>0.12.3-j</Version>
+    <Version>0.12.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/Dafda/Dafda.csproj
+++ b/src/Dafda/Dafda.csproj
@@ -7,7 +7,7 @@
     <Description>A small client for Kafka</Description>
     <RepositoryUrl>https://github.com/dfds/dafda</RepositoryUrl>
     <PackageProjectUrl>https://github.com/dfds/dafda</PackageProjectUrl>
-    <Version>0.12.4</Version>
+    <Version>0.12.3-j</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/Dafda/Diagnostics/DafdaActivitySource.cs
+++ b/src/Dafda/Diagnostics/DafdaActivitySource.cs
@@ -100,8 +100,6 @@ internal static class DafdaActivitySource
     public static Activity StartPublishingActivity(OutboxEntry entry, string clientId)
     {
         PropagationContext parentContext = default;
-        object messageType = string.Empty;
-        object messageId = string.Empty;
 
         if (!TryDeserializePayload(entry.Payload, out var payload))
         {
@@ -109,8 +107,11 @@ internal static class DafdaActivitySource
         }
 
         // extract message type
-        payload.TryGetValue("type", out messageType);
-        payload.TryGetValue("messageId", out messageId);
+        // extract message type and id
+        payload.TryGetValue("type", out var messageTypeToken);
+        payload.TryGetValue("messageId", out var messageIdToken);
+        var messageType = messageTypeToken?.ToString();
+        var messageId = messageIdToken?.ToString();
 
         // Extract the context injected in the metadata by the publisher
         parentContext = Propagator.Extract(default, payload, ExtractContextFromDictionary);


### PR DESCRIPTION
Outbox producer has incorrect serialization. This PR aims to fix it

Correct serialization:
`{"messageId":"579187ef-8008-45b9-9ae8-a9fc521df5a3","type":"UserPrimaryAssociateChanged","tenantId":"TEST","causationId":"c746294b-a83d-4266-bbe9-36f0461bccf0","correlationId":"7a7db530-3ce2-4e01-a2fd-0ae2a120a31e","data":{"id":"98312903-2273-4c66-abeb-f6c16892da78","primaryAssociate":0,"email":"D.KUKU@DD.COM","isDisabled":false}}
`

Wrong serialization that currently happens:
`{"messageId":"58f588b8-0fa9-42f9-ab4c-f02a23073422","type":"UserPrimaryAssociateChanged","data":"{\u0022id\u0022:\u0022ecf207c9-b471-4c6d-83ce-0b13a93cf00c\u0022,\u0022primaryAssociate\u0022:114850,\u0022email\u0022:\u0022ADMIN@DD.DD\u0022,\u0022isDisabled\u0022:false}","correlationId":"","causationId":"6abf73ef4938abcc","tenantId":"TEST","traceparent":"00-449309b89652796c36f382c583cc2ab5-4a44b34de7231936-01"}`

```

the \u0022 char breaks serialization/deserialization
exception_stacktrace=System.Text.Json.JsonException: The JSON value could not be converted to AssociateAccessRelationsChanged. 
```