### PR TITLE
Bugfix/dispatching wrong handler

### DIFF
--- a/src/Dafda.Tests/Builders/MessageResultBuilder.cs
+++ b/src/Dafda.Tests/Builders/MessageResultBuilder.cs
@@ -8,6 +8,7 @@ namespace Dafda.Tests.Builders
     {
         private TransportLevelMessage _message = new TransportLevelMessageBuilder().WithType("foo").Build();
         private Func<Task> _onCommit;
+        private string _topic = string.Empty;
 
         public MessageResultBuilder()
         {
@@ -26,9 +27,18 @@ namespace Dafda.Tests.Builders
             return this;
         }
 
+        public MessageResultBuilder WithTopic(string topic)
+        {
+            _topic = topic;
+            return this;
+        }
+
         public MessageResult Build()
         {
-            return new MessageResult(_message, _onCommit);
+            return new MessageResult(_message, _onCommit)
+            {
+                Topic = _topic ?? string.Empty
+            };
         }
     }
 }

--- a/src/Dafda.Tests/Configuration/TestConsumerConfigurationBuilder.cs
+++ b/src/Dafda.Tests/Configuration/TestConsumerConfigurationBuilder.cs
@@ -64,13 +64,16 @@ namespace Dafda.Tests.Configuration
         [Fact]
         public void Can_register_message_handler()
         {
+            const string topic = "dummyTopic";
+            const string messageType = nameof(DummyMessage);
+
             var configuration = new ConsumerConfigurationBuilder()
                 .WithGroupId("foo")
                 .WithBootstrapServers("bar")
-                .RegisterMessageHandler<DummyMessage, DummyMessageHandler>("dummyTopic", nameof(DummyMessage))
+                .RegisterMessageHandler<DummyMessage, DummyMessageHandler>(topic, messageType)
                 .Build();
 
-            var registration = configuration.MessageHandlerRegistry.GetRegistrationFor(nameof(DummyMessage));
+            var registration = configuration.MessageHandlerRegistry.GetRegistrationFor(topic, messageType);
 
             Assert.Equal(typeof(DummyMessageHandler), registration.HandlerInstanceType);
         }

--- a/src/Dafda.Tests/Configuration/TestConsumerServiceCollectionExtensions.cs
+++ b/src/Dafda.Tests/Configuration/TestConsumerServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ namespace Dafda.Tests.Configuration
         [Fact( /*Skip = "is this relevant for testing these extensions"*/)]
         public async Task Can_consume_message()
         {
+            const string dummyTopic = "dummyTopic";
             var dummyMessage = new DummyMessage();
             var messageStub = new TransportLevelMessageBuilder()
                 .WithType(nameof(DummyMessage))
@@ -29,6 +30,7 @@ namespace Dafda.Tests.Configuration
                 .Build();
             var messageResult = new MessageResultBuilder()
                 .WithTransportLevelMessage(messageStub)
+                .WithTopic(dummyTopic)
                 .Build();
 
             var services = new ServiceCollection();
@@ -38,7 +40,7 @@ namespace Dafda.Tests.Configuration
             {
                 options.WithBootstrapServers("dummyBootstrapServer");
                 options.WithGroupId("dummyGroupId");
-                options.RegisterMessageHandler<DummyMessage, DummyMessageHandler>("dummyTopic", nameof(DummyMessage));
+                options.RegisterMessageHandler<DummyMessage, DummyMessageHandler>(dummyTopic, nameof(DummyMessage));
 
                 options.WithConsumerScopeFactory(_ =>new ConsumerScopeFactoryStub(new ConsumerScopeStub(messageResult)));
             });
@@ -93,7 +95,9 @@ namespace Dafda.Tests.Configuration
                 .WithType(nameof(DummyMessage), parentId, "som=der")
                 .WithData(dummyMessage)
                 .Build();
+            const string dummyTopic = "dummyTopic";
             var messageResult = new MessageResultBuilder()
+                .WithTopic(dummyTopic)
                 .WithTransportLevelMessage(messageStub)
                 .Build();
 
@@ -104,7 +108,7 @@ namespace Dafda.Tests.Configuration
             {
                 options.WithBootstrapServers("dummyBootstrapServer");
                 options.WithGroupId("dummyGroupId");
-                options.RegisterMessageHandler<DummyMessage, DummyMessageHandler>("dummyTopic", nameof(DummyMessage));
+                options.RegisterMessageHandler<DummyMessage, DummyMessageHandler>(dummyTopic, nameof(DummyMessage));
                 options.WithConsumerScopeFactory(_ => new ConsumerScopeFactoryStub(new ConsumerScopeStub(messageResult)));
             });
             var serviceProvider = services.BuildServiceProvider();

--- a/src/Dafda.Tests/Configuration/TestServiceScope.cs
+++ b/src/Dafda.Tests/Configuration/TestServiceScope.cs
@@ -16,6 +16,7 @@ namespace Dafda.Tests.Configuration
         [Fact]
         public async Task Has_expected_number_of_creations_and_disposals_when_transient()
         {
+            const string dummyTopic = "dummyTopic";
             var dummyMessage = new DummyMessage();
             var messageStub = new TransportLevelMessageBuilder()
                 .WithType(nameof(DummyMessage))
@@ -23,6 +24,7 @@ namespace Dafda.Tests.Configuration
                 .Build();
             var messageResult = new MessageResultBuilder()
                 .WithTransportLevelMessage(messageStub)
+                .WithTopic(dummyTopic)
                 .Build();
 
             var services = new ServiceCollection();
@@ -41,7 +43,7 @@ namespace Dafda.Tests.Configuration
             var consumerConfiguration = new ConsumerConfigurationBuilder()
                 .WithGroupId("dummy")
                 .WithBootstrapServers("dummy")
-                .RegisterMessageHandler<DummyMessage, DummyMessageHandler>("dummyTopic", nameof(DummyMessage))
+                .RegisterMessageHandler<DummyMessage, DummyMessageHandler>(dummyTopic, nameof(DummyMessage))
                 .WithUnitOfWorkFactory(new ServiceProviderUnitOfWorkFactory(serviceProvider))
                 .Build();
 
@@ -62,6 +64,7 @@ namespace Dafda.Tests.Configuration
         [Fact]
         public async Task Has_expected_number_of_creations_and_disposals_when_singleton()
         {
+            const string dummyTopic = "dummyTopic";
             var dummyMessage = new DummyMessage();
             var messageStub = new TransportLevelMessageBuilder()
                 .WithType(nameof(DummyMessage))
@@ -69,6 +72,7 @@ namespace Dafda.Tests.Configuration
                 .Build();
             var messageResult = new MessageResultBuilder()
                 .WithTransportLevelMessage(messageStub)
+                .WithTopic(dummyTopic)
                 .Build();
 
             var services = new ServiceCollection();
@@ -87,7 +91,7 @@ namespace Dafda.Tests.Configuration
             var consumerConfiguration = new ConsumerConfigurationBuilder()
                 .WithGroupId("dummy")
                 .WithBootstrapServers("dummy")
-                .RegisterMessageHandler<DummyMessage, DummyMessageHandler>("dummyTopic", nameof(DummyMessage))
+                .RegisterMessageHandler<DummyMessage, DummyMessageHandler>(dummyTopic, nameof(DummyMessage))
                 .WithUnitOfWorkFactory(new ServiceProviderUnitOfWorkFactory(serviceProvider))
                 .Build();
 
@@ -108,6 +112,7 @@ namespace Dafda.Tests.Configuration
         [Fact]
         public async Task Has_expected_number_of_creations_and_disposals_when_scoped()
         {
+            const string dummyTopic = "dummyTopic";
             var dummyMessage = new DummyMessage();
             var messageStub = new TransportLevelMessageBuilder()
                 .WithType(nameof(DummyMessage))
@@ -115,6 +120,7 @@ namespace Dafda.Tests.Configuration
                 .Build();
             var messageResult = new MessageResultBuilder()
                 .WithTransportLevelMessage(messageStub)
+                .WithTopic(dummyTopic)
                 .Build();
 
             var services = new ServiceCollection();
@@ -133,7 +139,7 @@ namespace Dafda.Tests.Configuration
             var consumerConfiguration = new ConsumerConfigurationBuilder()
                 .WithGroupId("dummy")
                 .WithBootstrapServers("dummy")
-                .RegisterMessageHandler<DummyMessage, DummyMessageHandler>("dummyTopic", nameof(DummyMessage))
+                .RegisterMessageHandler<DummyMessage, DummyMessageHandler>(dummyTopic, nameof(DummyMessage))
                 .WithUnitOfWorkFactory(new ServiceProviderUnitOfWorkFactory(serviceProvider))
                 .Build();
 
@@ -154,6 +160,7 @@ namespace Dafda.Tests.Configuration
         [Fact]
         public async Task Has_expected_number_of_creations_and_disposals_when_scoped_2()
         {
+            const string dummyTopic = "dummyTopic";
             var dummyMessage = new DummyMessage();
             var messageStub = new TransportLevelMessageBuilder()
                 .WithType(nameof(DummyMessage))
@@ -161,6 +168,7 @@ namespace Dafda.Tests.Configuration
                 .Build();
             var messageResult = new MessageResultBuilder()
                 .WithTransportLevelMessage(messageStub)
+                .WithTopic(dummyTopic)
                 .Build();
 
             var services = new ServiceCollection();
@@ -179,7 +187,7 @@ namespace Dafda.Tests.Configuration
             var consumerConfiguration = new ConsumerConfigurationBuilder()
                 .WithGroupId("dummy")
                 .WithBootstrapServers("dummy")
-                .RegisterMessageHandler<DummyMessage, DummyMessageHandler>("dummyTopic", nameof(DummyMessage))
+                .RegisterMessageHandler<DummyMessage, DummyMessageHandler>(dummyTopic, nameof(DummyMessage))
                 .WithUnitOfWorkFactory(new ServiceProviderUnitOfWorkFactory(serviceProvider))
                 .Build();
 

--- a/src/Dafda.Tests/Consuming/TestConsumer.cs
+++ b/src/Dafda.Tests/Consuming/TestConsumer.cs
@@ -23,6 +23,7 @@ namespace Dafda.Tests.Consuming
                 .WithHandlerInstanceType(handlerStub.GetType())
                 .WithMessageInstanceType(typeof(FooMessage))
                 .WithMessageType("foo")
+                .WithTopic("")
                 .Build();
 
             var registry = new MessageHandlerRegistry();
@@ -66,8 +67,14 @@ namespace Dafda.Tests.Consuming
         {
             var orderOfInvocation = new LinkedList<string>();
 
-            var dummyMessageResult = new MessageResultBuilder().WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build()).Build();
-            var dummyMessageRegistration = new MessageRegistrationBuilder().WithMessageType("foo").Build();
+            var dummyMessageResult = new MessageResultBuilder()
+                .WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build())
+                .WithTopic("topic")
+                .Build();
+            var dummyMessageRegistration = new MessageRegistrationBuilder()
+                .WithMessageType("foo")
+                .WithTopic("topic")
+                .Build();
 
             var registry = new MessageHandlerRegistry();
             registry.Register(dummyMessageRegistration);
@@ -96,6 +103,7 @@ namespace Dafda.Tests.Consuming
                 .WithHandlerInstanceType(handlerStub.GetType())
                 .WithMessageInstanceType(typeof(FooMessage))
                 .WithMessageType("foo")
+                .WithTopic("topic")
                 .Build();
 
             var wasCalled = false;
@@ -106,6 +114,7 @@ namespace Dafda.Tests.Consuming
                     wasCalled = true;
                     return Task.CompletedTask;
                 })
+                .WithTopic("topic")
                 .Build();
 
             var consumerScopeFactoryStub = new ConsumerScopeFactoryStub(new ConsumerScopeStub(resultSpy));
@@ -133,11 +142,13 @@ namespace Dafda.Tests.Consuming
                 .WithHandlerInstanceType(handlerStub.GetType())
                 .WithMessageInstanceType(typeof(FooMessage))
                 .WithMessageType("foo")
+                .WithTopic("topic")
                 .Build();
 
             var wasCalled = false;
 
             var resultSpy = new MessageResultBuilder()
+                .WithTopic("topic")
                 .WithOnCommit(() =>
                 {
                     wasCalled = true;
@@ -164,13 +175,17 @@ namespace Dafda.Tests.Consuming
         [Fact]
         public async Task creates_consumer_scope_when_consuming_single_message()
         {
-            var messageResultStub = new MessageResultBuilder().WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build()).Build();
+            var messageResultStub = new MessageResultBuilder()
+                .WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build())
+                .WithTopic("topic")
+                .Build();
             var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
 
             var messageRegistrationStub = new MessageRegistrationBuilder()
                 .WithHandlerInstanceType(handlerStub.GetType())
                 .WithMessageInstanceType(typeof(FooMessage))
                 .WithMessageType("foo")
+                .WithTopic("topic")
                 .Build();
 
             var spy = new ConsumerScopeFactorySpy(new ConsumerScopeStub(messageResultStub));
@@ -193,13 +208,17 @@ namespace Dafda.Tests.Consuming
         [Fact]
         public async Task disposes_consumer_scope_when_consuming_single_message()
         {
-            var messageResultStub = new MessageResultBuilder().WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build()).Build();
+            var messageResultStub = new MessageResultBuilder()
+                .WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build())
+                .WithTopic("topic")
+                .Build();
             var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
 
             var messageRegistrationStub = new MessageRegistrationBuilder()
                 .WithHandlerInstanceType(handlerStub.GetType())
                 .WithMessageInstanceType(typeof(FooMessage))
                 .WithMessageType("foo")
+                .WithTopic("topic")
                 .Build();
 
             var spy = new ConsumerScopeSpy(messageResultStub);
@@ -222,13 +241,19 @@ namespace Dafda.Tests.Consuming
         [Fact]
         public async Task creates_consumer_scope_when_consuming_multiple_messages()
         {
-            var messageResultStub = new MessageResultBuilder().WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build()).Build();
+            var messageResultStub = new MessageResultBuilder()
+                    .WithTransportLevelMessage(new TransportLevelMessageBuilder()
+                    .WithType("foo")
+                    .Build())
+                    .WithTopic("topic")
+                    .Build();
             var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
 
             var messageRegistrationStub = new MessageRegistrationBuilder()
                 .WithHandlerInstanceType(handlerStub.GetType())
                 .WithMessageInstanceType(typeof(FooMessage))
                 .WithMessageType("foo")
+                .WithTopic("topic")
                 .Build();
 
             using (var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
@@ -269,13 +294,17 @@ namespace Dafda.Tests.Consuming
         [Fact]
         public async Task disposes_consumer_scope_when_consuming_multiple_messages()
         {
-            var messageResultStub = new MessageResultBuilder().WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build()).Build();
+            var messageResultStub = new MessageResultBuilder()
+                .WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build())
+                .WithTopic("topic")
+                .Build();
             var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
 
             var messageRegistrationStub = new MessageRegistrationBuilder()
                 .WithHandlerInstanceType(handlerStub.GetType())
                 .WithMessageInstanceType(typeof(FooMessage))
                 .WithMessageType("foo")
+                .WithTopic("topic")
                 .Build();
 
             using (var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5)))

--- a/src/Dafda.Tests/Consuming/TestLocalMessageDispatcher.cs
+++ b/src/Dafda.Tests/Consuming/TestLocalMessageDispatcher.cs
@@ -13,7 +13,7 @@ namespace Dafda.Tests.Consuming
         [Fact]
         public async Task throws_expected_exception_when_dispatching_and_no_handler_has_been_registered()
         {
-            var transportMessageStub = new TransportLevelMessageBuilder().Build();
+            var messageResultStub = new MessageResultBuilder().Build();
             var emptyMessageHandlerRegistryStub = new MessageHandlerRegistry();
             var dummyFactory = new HandlerUnitOfWorkFactoryStub(null);
 
@@ -22,14 +22,15 @@ namespace Dafda.Tests.Consuming
                 .WithHandlerUnitOfWorkFactory(dummyFactory)
                 .Build();
 
-            await Assert.ThrowsAsync<MissingMessageHandlerRegistrationException>(() => sut.Dispatch(transportMessageStub));
+            await Assert.ThrowsAsync<MissingMessageHandlerRegistrationException>(() => sut.Dispatch(messageResultStub));
         }
 
         [Fact]
         public async Task throws_expected_exception_when_dispatching_and_unable_to_resolve_handler_instance()
         {
-            var transportMessageStub = new TransportLevelMessageBuilder().WithType("foo").Build();
-            var messageRegistrationStub = new MessageRegistrationBuilder().WithMessageType("foo").Build();
+            var transportMessageDummy = new TransportLevelMessageBuilder().WithType("foo").Build();
+            var messageResultStub = new MessageResultBuilder().WithTopic("topic").WithTransportLevelMessage(transportMessageDummy).Build();
+            var messageRegistrationStub = new MessageRegistrationBuilder().WithTopic("topic").WithMessageType("foo").Build();
             var registry = new MessageHandlerRegistry();
             registry.Register(messageRegistrationStub);
 
@@ -38,7 +39,24 @@ namespace Dafda.Tests.Consuming
                 .WithHandlerUnitOfWorkFactory(new HandlerUnitOfWorkFactoryStub(null))
                 .Build();
 
-            await Assert.ThrowsAsync<UnableToResolveUnitOfWorkForHandlerException>(() => sut.Dispatch(transportMessageStub));
+            await Assert.ThrowsAsync<UnableToResolveUnitOfWorkForHandlerException>(() => sut.Dispatch(messageResultStub));
+        }
+
+        [Fact]
+        public async Task throws_expected_exception_when_dispatching_and_unable_to_resolve_handler_instance2()
+        {
+            var transportMessageDummy = new TransportLevelMessageBuilder().WithType("foo").Build();
+            var messageResultStub = new MessageResultBuilder().WithTopic("topic").WithTransportLevelMessage(transportMessageDummy).Build();
+            var messageRegistrationStub = new MessageRegistrationBuilder().WithTopic("topic-other").WithMessageType("foo").Build();
+            var registry = new MessageHandlerRegistry();
+            registry.Register(messageRegistrationStub);
+
+            var sut = new LocalMessageDispatcherBuilder()
+                .WithMessageHandlerRegistry(registry)
+                .WithHandlerUnitOfWorkFactory(new HandlerUnitOfWorkFactoryStub(null))
+                .Build();
+
+            await Assert.ThrowsAsync<MissingMessageHandlerRegistrationException>(() => sut.Dispatch(messageResultStub));
         }
 
         [Fact]
@@ -47,16 +65,17 @@ namespace Dafda.Tests.Consuming
             var mock = new Mock<IMessageHandler<object>>();
 
             var transportMessageDummy = new TransportLevelMessageBuilder().WithType("foo").Build();
-            var registrationDummy = new MessageRegistrationBuilder().WithMessageType("foo").Build();
+            var messageResultStub = new MessageResultBuilder().WithTopic("topic").WithTransportLevelMessage(transportMessageDummy).Build();
+            var registrationDummy = new MessageRegistrationBuilder().WithMessageType("foo").WithTopic("topic").Build();
             var registry = new MessageHandlerRegistry();
             registry.Register(registrationDummy);
-            
+
             var sut = new LocalMessageDispatcherBuilder()
                 .WithMessageHandlerRegistry(registry)
                 .WithHandlerUnitOfWork(new UnitOfWorkStub(mock.Object))
                 .Build();
 
-            await sut.Dispatch(transportMessageDummy);
+            await sut.Dispatch(messageResultStub);
 
             mock.Verify(x => x.Handle(It.IsAny<object>(), It.IsAny<MessageHandlerContext>()), Times.Once);
         }
@@ -65,18 +84,19 @@ namespace Dafda.Tests.Consuming
         public async Task handler_exceptions_are_thrown_as_expected()
         {
             var transportMessageDummy = new TransportLevelMessageBuilder().WithType("foo").Build();
-            var registrationDummy = new MessageRegistrationBuilder().WithMessageType("foo").Build();
+            var messageResultStub = new MessageResultBuilder().WithTopic("topic").WithTransportLevelMessage(transportMessageDummy).Build();
+            var registrationDummy = new MessageRegistrationBuilder().WithTopic("topic").WithMessageType("foo").Build();
             var registry = new MessageHandlerRegistry();
             registry.Register(registrationDummy);
-            
+
             var sut = new LocalMessageDispatcherBuilder()
                 .WithMessageHandlerRegistry(registry)
                 .WithHandlerUnitOfWork(new UnitOfWorkStub(new ErroneusHandler()))
                 .Build();
 
-            await Assert.ThrowsAsync<ExpectedException>(() => sut.Dispatch(transportMessageDummy));
+            await Assert.ThrowsAsync<ExpectedException>(() => sut.Dispatch(messageResultStub));
         }
-        
+
         #region private helper classes
 
         private class ExpectedException : Exception

--- a/src/Dafda/Consuming/Consumer.cs
+++ b/src/Dafda/Consuming/Consumer.cs
@@ -60,7 +60,7 @@ namespace Dafda.Consuming
 
             if(_messageFilter.CanAcceptMessage(messageResult))
             {
-                await _localMessageDispatcher.Dispatch(messageResult.Message);
+                await _localMessageDispatcher.Dispatch(messageResult);
             }
 
             if (!_isAutoCommitEnabled)

--- a/src/Dafda/Consuming/MessageHandlerRegistry.cs
+++ b/src/Dafda/Consuming/MessageHandlerRegistry.cs
@@ -8,8 +8,8 @@ namespace Dafda.Consuming
     {
         private readonly List<MessageRegistration> _registrations = new List<MessageRegistration>();
 
-        public void Register<TMessage, THandler>(string topic, string messageType) 
-            where THandler : IMessageHandler<TMessage> 
+        public void Register<TMessage, THandler>(string topic, string messageType)
+            where THandler : IMessageHandler<TMessage>
         {
             Register(
                 handlerInstanceType: typeof(THandler),
@@ -42,9 +42,9 @@ namespace Dafda.Consuming
 
         public IEnumerable<MessageRegistration> Registrations => _registrations;
 
-        public MessageRegistration GetRegistrationFor(string messageType)
+        public MessageRegistration GetRegistrationFor(string topic, string messageType)
         {
-            return _registrations.SingleOrDefault(x => x.MessageType == messageType);
+            return _registrations.SingleOrDefault(x => x.MessageType == messageType && x.Topic == topic);
         }
     }
 }


### PR DESCRIPTION
Should fix a bug described in #95 
The fix will make querying of message registration consistent with how registrations are added (topicName + messageType).