### PR TITLE
Made the DefaultPayloadSerializer be reused by the TopicPayloadSerial…

### DIFF
--- a/src/Dafda/Configuration/ProducerConfigurationBuilder.cs
+++ b/src/Dafda/Configuration/ProducerConfigurationBuilder.cs
@@ -32,7 +32,8 @@ namespace Dafda.Configuration
         private ConfigurationSource _configurationSource = ConfigurationSource.Null;
         private MessageIdGenerator _messageIdGenerator = MessageIdGenerator.Default;
         private Func<ILoggerFactory, KafkaProducer> _kafkaProducerFactory;
-        private readonly TopicPayloadSerializerRegistry _topicPayloadSerializerRegistry = new TopicPayloadSerializerRegistry(() => new DefaultPayloadSerializer());
+        private static readonly IPayloadSerializer _defaultPayloadSerializer = new DefaultPayloadSerializer();
+        private readonly TopicPayloadSerializerRegistry _topicPayloadSerializerRegistry = new TopicPayloadSerializerRegistry(() => _defaultPayloadSerializer);
 
         public ProducerConfigurationBuilder WithConfigurationSource(ConfigurationSource configurationSource)
         {


### PR DESCRIPTION
This pull request makes a minor update to the `ProducerConfigurationBuilder` class to improve the handling of the default payload serializer. The change ensures that a single static instance of `DefaultPayloadSerializer` is used, rather than creating a new instance each time.

- **Payload serializer optimization:**
  * Updated `ProducerConfigurationBuilder` to use a static instance of `DefaultPayloadSerializer` for the default payload serializer, improving efficiency and consistency.