### PR TITLE
Add Dead Letter Queue support to the consumer pipeline

### DIFF
--- a/src/Dafda.Tests/Builders/ConsumerBuilder.cs
+++ b/src/Dafda.Tests/Builders/ConsumerBuilder.cs
@@ -1,78 +1,84 @@
-﻿using Dafda.Consuming;
+﻿namespace Dafda.Tests.Builders;
+
+using Dafda.Consuming;
 using Dafda.Consuming.MessageFilters;
-using Dafda.Tests.TestDoubles;
+using TestDoubles;
 
-namespace Dafda.Tests.Builders
+internal class ConsumerBuilder
 {
-    internal class ConsumerBuilder
+    private IHandlerUnitOfWorkFactory _unitOfWorkFactory = new HandlerUnitOfWorkFactoryStub(null);
+    private IConsumerScopeFactory _consumerScopeFactory = new ConsumerScopeFactoryStub(new ConsumerScopeStub(new MessageResultBuilder().Build()));
+    private MessageHandlerRegistry _registry = new();
+    private IUnconfiguredMessageHandlingStrategy _unconfiguredMessageStrategy = new RequireExplicitHandlers();
+    private readonly IMessageHandlerExecutionStrategy _messageHandlerExecutionStrategy = new DirectMessageHandlerExecutionStrategy();
+
+    private bool _enableAutoCommit;
+    private MessageFilter _messageFilter = MessageFilter.Default;
+    private IDeadLetterQueue _deadLetterQueue = NullDeadLetterQueue.Instance;
+    private int _maxRetries;
+
+    public ConsumerBuilder WithUnitOfWork(IHandlerUnitOfWork unitOfWork)
     {
-        private IHandlerUnitOfWorkFactory _unitOfWorkFactory;
-        private IConsumerScopeFactory _consumerScopeFactory;
-        private MessageHandlerRegistry _registry;
-        private IUnconfiguredMessageHandlingStrategy _unconfiguredMessageStrategy;
-        private IMessageHandlerExecutionStrategy _messageHandlerExecutionStrategy;
-
-        private bool _enableAutoCommit;
-        private MessageFilter _messageFilter = MessageFilter.Default;
-
-        public ConsumerBuilder()
-        {
-            _unitOfWorkFactory = new HandlerUnitOfWorkFactoryStub(null);
-            _consumerScopeFactory = new ConsumerScopeFactoryStub(new ConsumerScopeStub(new MessageResultBuilder().Build()));
-            _registry = new MessageHandlerRegistry();
-            _unconfiguredMessageStrategy = new RequireExplicitHandlers();
-            _messageHandlerExecutionStrategy = new DirectMessageHandlerExecutionStrategy();
-        }
-
-        public ConsumerBuilder WithUnitOfWork(IHandlerUnitOfWork unitOfWork)
-        {
-            return WithUnitOfWorkFactory(new HandlerUnitOfWorkFactoryStub(unitOfWork));
-        }
-
-        public ConsumerBuilder WithUnitOfWorkFactory(IHandlerUnitOfWorkFactory unitofWorkFactory)
-        {
-            _unitOfWorkFactory = unitofWorkFactory;
-            return this;
-        }
-
-        public ConsumerBuilder WithConsumerScopeFactory(IConsumerScopeFactory consumerScopeFactory)
-        {
-            _consumerScopeFactory = consumerScopeFactory;
-            return this;
-        }
-
-        public ConsumerBuilder WithMessageHandlerRegistry(MessageHandlerRegistry registry)
-        {
-            _registry = registry;
-            return this;
-        }
-
-        public ConsumerBuilder WithEnableAutoCommit(bool enableAutoCommit)
-        {
-            _enableAutoCommit = enableAutoCommit;
-            return this;
-        }
-
-        public void WithMessageFilter(MessageFilter messageFilter)
-        {
-            _messageFilter = messageFilter;
-        }
-
-        public ConsumerBuilder WithUnconfiguredMessageStrategy(
-            IUnconfiguredMessageHandlingStrategy strategy)
-        {
-            _unconfiguredMessageStrategy = strategy;
-            return this;
-        }
-
-        public Consumer Build() =>
-            new Consumer(
-                _registry,
-                _unitOfWorkFactory,
-                _consumerScopeFactory,
-                _unconfiguredMessageStrategy,
-                _messageFilter,
-                _messageHandlerExecutionStrategy,
-                _enableAutoCommit);
+        return WithUnitOfWorkFactory(new HandlerUnitOfWorkFactoryStub(unitOfWork));
     }
+
+    public ConsumerBuilder WithUnitOfWorkFactory(IHandlerUnitOfWorkFactory unitofWorkFactory)
+    {
+        _unitOfWorkFactory = unitofWorkFactory;
+        return this;
+    }
+
+    public ConsumerBuilder WithConsumerScopeFactory(IConsumerScopeFactory consumerScopeFactory)
+    {
+        _consumerScopeFactory = consumerScopeFactory;
+        return this;
+    }
+
+    public ConsumerBuilder WithMessageHandlerRegistry(MessageHandlerRegistry registry)
+    {
+        _registry = registry;
+        return this;
+    }
+
+    public ConsumerBuilder WithEnableAutoCommit(bool enableAutoCommit)
+    {
+        _enableAutoCommit = enableAutoCommit;
+        return this;
+    }
+
+    public void WithMessageFilter(MessageFilter messageFilter)
+    {
+        _messageFilter = messageFilter;
+    }
+
+    public ConsumerBuilder WithUnconfiguredMessageStrategy(
+        IUnconfiguredMessageHandlingStrategy strategy)
+    {
+        _unconfiguredMessageStrategy = strategy;
+        return this;
+    }
+
+    public ConsumerBuilder WithDeadLetterQueue(IDeadLetterQueue deadLetterQueue)
+    {
+        _deadLetterQueue = deadLetterQueue;
+        return this;
+    }
+
+    public ConsumerBuilder WithMaxRetries(int maxRetries)
+    {
+        _maxRetries = maxRetries;
+        return this;
+    }
+
+    public Consumer Build() =>
+        new Consumer(
+            _registry,
+            _unitOfWorkFactory,
+            _consumerScopeFactory,
+            _unconfiguredMessageStrategy,
+            _messageFilter,
+            _messageHandlerExecutionStrategy,
+            _enableAutoCommit,
+            _deadLetterQueue,
+            _maxRetries);
 }

--- a/src/Dafda.Tests/Consuming/TestConsumer.cs
+++ b/src/Dafda.Tests/Consuming/TestConsumer.cs
@@ -431,6 +431,30 @@ public class TestConsumer
             () => sut.ConsumeSingle(CancellationToken.None));
     }
 
+    [Fact]
+    public async Task does_not_dead_letter_when_cancelled_during_dispatch()
+    {
+        using var cts = new CancellationTokenSource();
+
+        var handler = new MessageHandlerSpy<FooMessage>(() =>
+        {
+            cts.Cancel();
+            cts.Token.ThrowIfCancellationRequested();
+        });
+
+        var deadLetterQueueSpy = new DeadLetterQueueSpy();
+
+        var sut = BuildConsumerWithHandler(
+            handler,
+            deadLetterQueue: deadLetterQueueSpy,
+            maxRetries: 3);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => sut.ConsumeSingle(cts.Token));
+
+        Assert.Equal(0, deadLetterQueueSpy.SendCount);
+    }
+
     private static Consumer BuildConsumerWithHandler(
         IMessageHandler<FooMessage> handler,
         Func<CancellationToken, Task> onCommit = null,

--- a/src/Dafda.Tests/Consuming/TestConsumer.cs
+++ b/src/Dafda.Tests/Consuming/TestConsumer.cs
@@ -1,194 +1,279 @@
-﻿using System;
+﻿namespace Dafda.Tests.Consuming;
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Builders;
 using Dafda.Consuming;
-using Dafda.Tests.Builders;
-using Dafda.Tests.TestDoubles;
 using Microsoft.Extensions.Logging;
 using Moq;
+using TestDoubles;
 using Xunit;
 
-namespace Dafda.Tests.Consuming
+public class TestConsumer
 {
-    public class TestConsumer
+    [Fact]
+    public async Task invokes_expected_handler_when_consuming()
     {
-        [Fact]
-        public async Task invokes_expected_handler_when_consuming()
+        var handlerMock = new Mock<IMessageHandler<FooMessage>>();
+        var handlerStub = handlerMock.Object;
+
+        var messageRegistrationStub = new MessageRegistrationBuilder()
+            .WithHandlerInstanceType(handlerStub.GetType())
+            .WithMessageInstanceType(typeof(FooMessage))
+            .WithMessageType("foo")
+            .WithTopic("")
+            .Build();
+
+        var registry = new MessageHandlerRegistry();
+        registry.Register(messageRegistrationStub);
+
+        var sut = new ConsumerBuilder()
+            .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
+            .WithMessageHandlerRegistry(registry)
+            .Build();
+
+        await sut.ConsumeSingle(CancellationToken.None);
+
+        handlerMock.Verify(x => x.Handle(It.IsAny<FooMessage>(), It.IsAny<MessageHandlerContext>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task throws_when_consuming_an_unknown_message_when_explicit_handlers_are_required()
+    {
+        var sut = new ConsumerBuilder().Build();
+
+        await Assert.ThrowsAsync<MissingMessageHandlerRegistrationException>(
+            () => sut.ConsumeSingle(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task does_not_throw_when_consuming_an_unknown_message_with_no_op_strategy()
+    {
+        var sut =
+            new ConsumerBuilder()
+                .WithUnitOfWork(
+                    new UnitOfWorkStub(
+                        new NoOpHandler(new Mock<ILogger<NoOpHandler>>().Object)))
+                .WithUnconfiguredMessageStrategy(new UseNoOpHandler())
+                .Build();
+
+        await sut.ConsumeSingle(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task expected_order_of_handler_invocation_in_unit_of_work()
+    {
+        var orderOfInvocation = new LinkedList<string>();
+
+        var dummyMessageResult = new MessageResultBuilder()
+            .WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build())
+            .WithTopic("topic")
+            .Build();
+        var dummyMessageRegistration = new MessageRegistrationBuilder()
+            .WithMessageType("foo")
+            .WithTopic("topic")
+            .Build();
+
+        var registry = new MessageHandlerRegistry();
+        registry.Register(dummyMessageRegistration);
+
+        var sut = new ConsumerBuilder()
+            .WithUnitOfWork(new UnitOfWorkSpy(
+                handlerInstance: new MessageHandlerSpy<FooMessage>(() => orderOfInvocation.AddLast("during")),
+                pre: () => orderOfInvocation.AddLast("before"),
+                post: () => orderOfInvocation.AddLast("after")
+            ))
+            .WithConsumerScopeFactory(new ConsumerScopeFactoryStub(new ConsumerScopeStub(dummyMessageResult)))
+            .WithMessageHandlerRegistry(registry)
+            .Build();
+
+        await sut.ConsumeSingle(CancellationToken.None);
+
+        Assert.Equal(new[] { "before", "during", "after" }, orderOfInvocation);
+    }
+
+    [Fact]
+    public async Task will_not_call_commit_when_auto_commit_is_enabled()
+    {
+        var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
+
+        var messageRegistrationStub = new MessageRegistrationBuilder()
+            .WithHandlerInstanceType(handlerStub.GetType())
+            .WithMessageInstanceType(typeof(FooMessage))
+            .WithMessageType("foo")
+            .WithTopic("topic")
+            .Build();
+
+        var wasCalled = false;
+
+        var resultSpy = new MessageResultBuilder()
+            .WithOnCommit((_) =>
+            {
+                wasCalled = true;
+                return Task.CompletedTask;
+            })
+            .WithTopic("topic")
+            .Build();
+
+        var consumerScopeFactoryStub = new ConsumerScopeFactoryStub(new ConsumerScopeStub(resultSpy));
+        var registry = new MessageHandlerRegistry();
+        registry.Register(messageRegistrationStub);
+
+        var consumer = new ConsumerBuilder()
+            .WithConsumerScopeFactory(consumerScopeFactoryStub)
+            .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
+            .WithMessageHandlerRegistry(registry)
+            .WithEnableAutoCommit(true)
+            .Build();
+
+        await consumer.ConsumeSingle(CancellationToken.None);
+
+        Assert.False(wasCalled);
+    }
+
+    [Fact]
+    public async Task will_call_commit_when_auto_commit_is_disabled()
+    {
+        var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
+
+        var messageRegistrationStub = new MessageRegistrationBuilder()
+            .WithHandlerInstanceType(handlerStub.GetType())
+            .WithMessageInstanceType(typeof(FooMessage))
+            .WithMessageType("foo")
+            .WithTopic("topic")
+            .Build();
+
+        var wasCalled = false;
+
+        var resultSpy = new MessageResultBuilder()
+            .WithTopic("topic")
+            .WithOnCommit((_) =>
+            {
+                wasCalled = true;
+                return Task.CompletedTask;
+            })
+            .Build();
+
+        var consumerScopeFactoryStub = new ConsumerScopeFactoryStub(new ConsumerScopeStub(resultSpy));
+        var registry = new MessageHandlerRegistry();
+        registry.Register(messageRegistrationStub);
+
+        var consumer = new ConsumerBuilder()
+            .WithConsumerScopeFactory(consumerScopeFactoryStub)
+            .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
+            .WithMessageHandlerRegistry(registry)
+            .WithEnableAutoCommit(false)
+            .Build();
+
+        await consumer.ConsumeSingle(CancellationToken.None);
+
+        Assert.True(wasCalled);
+    }
+
+    [Fact]
+    public async Task creates_consumer_scope_when_consuming_single_message()
+    {
+        var messageResultStub = new MessageResultBuilder()
+            .WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build())
+            .WithTopic("topic")
+            .Build();
+        var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
+
+        var messageRegistrationStub = new MessageRegistrationBuilder()
+            .WithHandlerInstanceType(handlerStub.GetType())
+            .WithMessageInstanceType(typeof(FooMessage))
+            .WithMessageType("foo")
+            .WithTopic("topic")
+            .Build();
+
+        var spy = new ConsumerScopeFactorySpy(new ConsumerScopeStub(messageResultStub));
+
+        var registry = new MessageHandlerRegistry();
+        registry.Register(messageRegistrationStub);
+
+        var consumer = new ConsumerBuilder()
+            .WithConsumerScopeFactory(spy)
+            .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
+            .WithMessageHandlerRegistry(registry)
+            .Build();
+
+        await consumer.ConsumeSingle(CancellationToken.None);
+
+
+        Assert.Equal(1, spy.CreateConsumerScopeCalled);
+    }
+
+    [Fact]
+    public async Task disposes_consumer_scope_when_consuming_single_message()
+    {
+        var messageResultStub = new MessageResultBuilder()
+            .WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build())
+            .WithTopic("topic")
+            .Build();
+        var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
+
+        var messageRegistrationStub = new MessageRegistrationBuilder()
+            .WithHandlerInstanceType(handlerStub.GetType())
+            .WithMessageInstanceType(typeof(FooMessage))
+            .WithMessageType("foo")
+            .WithTopic("topic")
+            .Build();
+
+        var spy = new ConsumerScopeSpy(messageResultStub);
+
+        var registry = new MessageHandlerRegistry();
+        registry.Register(messageRegistrationStub);
+
+        var consumer = new ConsumerBuilder()
+            .WithConsumerScopeFactory(new ConsumerScopeFactoryStub(spy))
+            .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
+            .WithMessageHandlerRegistry(registry)
+            .Build();
+
+        await consumer.ConsumeSingle(CancellationToken.None);
+
+
+        Assert.Equal(1, spy.Disposed);
+    }
+
+    [Fact]
+    public async Task creates_consumer_scope_when_consuming_multiple_messages()
+    {
+        var messageResultStub = new MessageResultBuilder()
+            .WithTransportLevelMessage(new TransportLevelMessageBuilder()
+                .WithType("foo")
+                .Build())
+            .WithTopic("topic")
+            .Build();
+        var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
+
+        var messageRegistrationStub = new MessageRegistrationBuilder()
+            .WithHandlerInstanceType(handlerStub.GetType())
+            .WithMessageInstanceType(typeof(FooMessage))
+            .WithMessageType("foo")
+            .WithTopic("topic")
+            .Build();
+
+        using (var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
         {
-            var handlerMock = new Mock<IMessageHandler<FooMessage>>();
-            var handlerStub = handlerMock.Object;
+            var loops = 0;
 
-            var messageRegistrationStub = new MessageRegistrationBuilder()
-                .WithHandlerInstanceType(handlerStub.GetType())
-                .WithMessageInstanceType(typeof(FooMessage))
-                .WithMessageType("foo")
-                .WithTopic("")
-                .Build();
-
-            var registry = new MessageHandlerRegistry();
-            registry.Register(messageRegistrationStub);
-
-            var sut = new ConsumerBuilder()
-                .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
-                .WithMessageHandlerRegistry(registry)
-                .Build();
-
-            await sut.ConsumeSingle(CancellationToken.None);
-
-            handlerMock.Verify(x => x.Handle(It.IsAny<FooMessage>(), It.IsAny<MessageHandlerContext>(), It.IsAny<CancellationToken>()), Times.Once);
-        }
-
-        [Fact]
-        public async Task throws_when_consuming_an_unknown_message_when_explicit_handlers_are_required()
-        {
-            var sut = new ConsumerBuilder().Build();
-
-            await Assert.ThrowsAsync<MissingMessageHandlerRegistrationException>(
-                () => sut.ConsumeSingle(CancellationToken.None));
-        }
-
-        [Fact]
-        public async Task does_not_throw_when_consuming_an_unknown_message_with_no_op_strategy()
-        {
-            var sut =
-                new ConsumerBuilder()
-                    .WithUnitOfWork(
-                        new UnitOfWorkStub(
-                            new NoOpHandler(new Mock<ILogger<NoOpHandler>>().Object)))
-                    .WithUnconfiguredMessageStrategy(new UseNoOpHandler())
-                    .Build();
-
-            await sut.ConsumeSingle(CancellationToken.None);
-        }
-
-        [Fact]
-        public async Task expected_order_of_handler_invocation_in_unit_of_work()
-        {
-            var orderOfInvocation = new LinkedList<string>();
-
-            var dummyMessageResult = new MessageResultBuilder()
-                .WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build())
-                .WithTopic("topic")
-                .Build();
-            var dummyMessageRegistration = new MessageRegistrationBuilder()
-                .WithMessageType("foo")
-                .WithTopic("topic")
-                .Build();
-
-            var registry = new MessageHandlerRegistry();
-            registry.Register(dummyMessageRegistration);
-
-            var sut = new ConsumerBuilder()
-                .WithUnitOfWork(new UnitOfWorkSpy(
-                    handlerInstance: new MessageHandlerSpy<FooMessage>(() => orderOfInvocation.AddLast("during")),
-                    pre: () => orderOfInvocation.AddLast("before"),
-                    post: () => orderOfInvocation.AddLast("after")
-                ))
-                .WithConsumerScopeFactory(new ConsumerScopeFactoryStub(new ConsumerScopeStub(dummyMessageResult)))
-                .WithMessageHandlerRegistry(registry)
-                .Build();
-
-            await sut.ConsumeSingle(CancellationToken.None);
-
-            Assert.Equal(new[] { "before", "during", "after" }, orderOfInvocation);
-        }
-
-        [Fact]
-        public async Task will_not_call_commit_when_auto_commit_is_enabled()
-        {
-            var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
-
-            var messageRegistrationStub = new MessageRegistrationBuilder()
-                .WithHandlerInstanceType(handlerStub.GetType())
-                .WithMessageInstanceType(typeof(FooMessage))
-                .WithMessageType("foo")
-                .WithTopic("topic")
-                .Build();
-
-            var wasCalled = false;
-
-            var resultSpy = new MessageResultBuilder()
-                .WithOnCommit((_) =>
+            var subscriberScopeStub = new ConsumerScopeDecoratorWithHooks(
+                inner: new ConsumerScopeStub(messageResultStub),
+                postHook: () =>
                 {
-                    wasCalled = true;
-                    return Task.CompletedTask;
-                })
-                .WithTopic("topic")
-                .Build();
+                    loops++;
 
-            var consumerScopeFactoryStub = new ConsumerScopeFactoryStub(new ConsumerScopeStub(resultSpy));
-            var registry = new MessageHandlerRegistry();
-            registry.Register(messageRegistrationStub);
+                    if (loops == 2)
+                    {
+                        cancellationTokenSource.Cancel();
+                    }
+                }
+            );
 
-            var consumer = new ConsumerBuilder()
-                .WithConsumerScopeFactory(consumerScopeFactoryStub)
-                .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
-                .WithMessageHandlerRegistry(registry)
-                .WithEnableAutoCommit(true)
-                .Build();
-
-            await consumer.ConsumeSingle(CancellationToken.None);
-
-            Assert.False(wasCalled);
-        }
-
-        [Fact]
-        public async Task will_call_commit_when_auto_commit_is_disabled()
-        {
-            var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
-
-            var messageRegistrationStub = new MessageRegistrationBuilder()
-                .WithHandlerInstanceType(handlerStub.GetType())
-                .WithMessageInstanceType(typeof(FooMessage))
-                .WithMessageType("foo")
-                .WithTopic("topic")
-                .Build();
-
-            var wasCalled = false;
-
-            var resultSpy = new MessageResultBuilder()
-                .WithTopic("topic")
-                .WithOnCommit((_) =>
-                {
-                    wasCalled = true;
-                    return Task.CompletedTask;
-                })
-                .Build();
-
-            var consumerScopeFactoryStub = new ConsumerScopeFactoryStub(new ConsumerScopeStub(resultSpy));
-            var registry = new MessageHandlerRegistry();
-            registry.Register(messageRegistrationStub);
-
-            var consumer = new ConsumerBuilder()
-                .WithConsumerScopeFactory(consumerScopeFactoryStub)
-                .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
-                .WithMessageHandlerRegistry(registry)
-                .WithEnableAutoCommit(false)
-                .Build();
-
-            await consumer.ConsumeSingle(CancellationToken.None);
-
-            Assert.True(wasCalled);
-        }
-
-        [Fact]
-        public async Task creates_consumer_scope_when_consuming_single_message()
-        {
-            var messageResultStub = new MessageResultBuilder()
-                .WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build())
-                .WithTopic("topic")
-                .Build();
-            var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
-
-            var messageRegistrationStub = new MessageRegistrationBuilder()
-                .WithHandlerInstanceType(handlerStub.GetType())
-                .WithMessageInstanceType(typeof(FooMessage))
-                .WithMessageType("foo")
-                .WithTopic("topic")
-                .Build();
-
-            var spy = new ConsumerScopeFactorySpy(new ConsumerScopeStub(messageResultStub));
+            var spy = new ConsumerScopeFactorySpy(subscriberScopeStub);
 
             var registry = new MessageHandlerRegistry();
             registry.Register(messageRegistrationStub);
@@ -199,29 +284,42 @@ namespace Dafda.Tests.Consuming
                 .WithMessageHandlerRegistry(registry)
                 .Build();
 
-            await consumer.ConsumeSingle(CancellationToken.None);
+            await consumer.ConsumeAll(cancellationTokenSource.Token);
 
-
+            Assert.Equal(2, loops);
             Assert.Equal(1, spy.CreateConsumerScopeCalled);
         }
+    }
 
-        [Fact]
-        public async Task disposes_consumer_scope_when_consuming_single_message()
+    [Fact]
+    public async Task disposes_consumer_scope_when_consuming_multiple_messages()
+    {
+        var messageResultStub = new MessageResultBuilder()
+            .WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build())
+            .WithTopic("topic")
+            .Build();
+        var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
+
+        var messageRegistrationStub = new MessageRegistrationBuilder()
+            .WithHandlerInstanceType(handlerStub.GetType())
+            .WithMessageInstanceType(typeof(FooMessage))
+            .WithMessageType("foo")
+            .WithTopic("topic")
+            .Build();
+
+        using (var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
         {
-            var messageResultStub = new MessageResultBuilder()
-                .WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build())
-                .WithTopic("topic")
-                .Build();
-            var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
+            var loops = 0;
 
-            var messageRegistrationStub = new MessageRegistrationBuilder()
-                .WithHandlerInstanceType(handlerStub.GetType())
-                .WithMessageInstanceType(typeof(FooMessage))
-                .WithMessageType("foo")
-                .WithTopic("topic")
-                .Build();
+            var spy = new ConsumerScopeSpy(messageResultStub, () =>
+            {
+                loops++;
 
-            var spy = new ConsumerScopeSpy(messageResultStub);
+                if (loops == 2)
+                {
+                    cancellationTokenSource.Cancel();
+                }
+            });
 
             var registry = new MessageHandlerRegistry();
             registry.Register(messageRegistrationStub);
@@ -232,199 +330,218 @@ namespace Dafda.Tests.Consuming
                 .WithMessageHandlerRegistry(registry)
                 .Build();
 
-            await consumer.ConsumeSingle(CancellationToken.None);
+            await consumer.ConsumeAll(cancellationTokenSource.Token);
 
-
+            Assert.Equal(2, loops);
             Assert.Equal(1, spy.Disposed);
         }
-
-        [Fact]
-        public async Task creates_consumer_scope_when_consuming_multiple_messages()
-        {
-            var messageResultStub = new MessageResultBuilder()
-                    .WithTransportLevelMessage(new TransportLevelMessageBuilder()
-                    .WithType("foo")
-                    .Build())
-                    .WithTopic("topic")
-                    .Build();
-            var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
-
-            var messageRegistrationStub = new MessageRegistrationBuilder()
-                .WithHandlerInstanceType(handlerStub.GetType())
-                .WithMessageInstanceType(typeof(FooMessage))
-                .WithMessageType("foo")
-                .WithTopic("topic")
-                .Build();
-
-            using (var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
-            {
-                var loops = 0;
-
-                var subscriberScopeStub = new ConsumerScopeDecoratorWithHooks(
-                    inner: new ConsumerScopeStub(messageResultStub),
-                    postHook: () =>
-                    {
-                        loops++;
-
-                        if (loops == 2)
-                        {
-                            cancellationTokenSource.Cancel();
-                        }
-                    }
-                );
-
-                var spy = new ConsumerScopeFactorySpy(subscriberScopeStub);
-
-                var registry = new MessageHandlerRegistry();
-                registry.Register(messageRegistrationStub);
-
-                var consumer = new ConsumerBuilder()
-                    .WithConsumerScopeFactory(spy)
-                    .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
-                    .WithMessageHandlerRegistry(registry)
-                    .Build();
-
-                await consumer.ConsumeAll(cancellationTokenSource.Token);
-
-                Assert.Equal(2, loops);
-                Assert.Equal(1, spy.CreateConsumerScopeCalled);
-            }
-        }
-
-        [Fact]
-        public async Task disposes_consumer_scope_when_consuming_multiple_messages()
-        {
-            var messageResultStub = new MessageResultBuilder()
-                .WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build())
-                .WithTopic("topic")
-                .Build();
-            var handlerStub = Dummy.Of<IMessageHandler<FooMessage>>();
-
-            var messageRegistrationStub = new MessageRegistrationBuilder()
-                .WithHandlerInstanceType(handlerStub.GetType())
-                .WithMessageInstanceType(typeof(FooMessage))
-                .WithMessageType("foo")
-                .WithTopic("topic")
-                .Build();
-
-            using (var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
-            {
-                var loops = 0;
-
-                var spy = new ConsumerScopeSpy(messageResultStub, () =>
-                {
-                    loops++;
-
-                    if (loops == 2)
-                    {
-                        cancellationTokenSource.Cancel();
-                    }
-                });
-
-                var registry = new MessageHandlerRegistry();
-                registry.Register(messageRegistrationStub);
-
-                var consumer = new ConsumerBuilder()
-                    .WithConsumerScopeFactory(new ConsumerScopeFactoryStub(spy))
-                    .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
-                    .WithMessageHandlerRegistry(registry)
-                    .Build();
-
-                await consumer.ConsumeAll(cancellationTokenSource.Token);
-
-                Assert.Equal(2, loops);
-                Assert.Equal(1, spy.Disposed);
-            }
-        }
-
-        [Fact]
-        public async Task throws_when_task_is_canceled()
-        {
-            using var cts = new CancellationTokenSource();
-            cts.Cancel();
-
-            var handlerMock = new Mock<IMessageHandler<FooMessage>>();
-            var handlerStub = handlerMock.Object;
-
-            var messageRegistrationStub = new MessageRegistrationBuilder()
-                .WithHandlerInstanceType(handlerStub.GetType())
-                .WithMessageInstanceType(typeof(FooMessage))
-                .WithMessageType("foo")
-                .WithTopic("")
-                .Build();
-
-            var registry = new MessageHandlerRegistry();
-            registry.Register(messageRegistrationStub);
-
-            var sut = new ConsumerBuilder()
-                .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
-                .WithMessageHandlerRegistry(registry)
-                .Build();
-
-            await Assert.ThrowsAsync<OperationCanceledException>(() => sut.ConsumeSingle(cts.Token));
-        }
-        #region helper classes
-
-        private class ConsumerScopeDecoratorWithHooks : ConsumerScope
-        {
-            private readonly ConsumerScope _inner;
-            private readonly Action _preHook;
-            private readonly Action _postHook;
-
-            public ConsumerScopeDecoratorWithHooks(ConsumerScope inner, Action preHook = null, Action postHook = null)
-            {
-                _inner = inner;
-                _preHook = preHook;
-                _postHook = postHook;
-            }
-
-            public override async Task<MessageResult> GetNext(CancellationToken cancellationToken)
-            {
-                _preHook?.Invoke();
-                var result = await _inner.GetNext(cancellationToken);
-                _postHook?.Invoke();
-
-                return result;
-            }
-
-            public override void Dispose()
-            {
-                _inner.Dispose();
-            }
-        }
-
-        public class FooMessage
-        {
-            public string Value { get; set; }
-        }
-
-        #endregion
     }
 
-    internal class ConsumerScopeSpy : ConsumerScope
+    [Fact]
+    public async Task throws_when_task_is_canceled()
     {
-        private readonly MessageResult _messageResult;
-        private readonly Action _onGetNext;
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
 
-        public ConsumerScopeSpy(MessageResult messageResult, Action onGetNext = null)
+        var handlerMock = new Mock<IMessageHandler<FooMessage>>();
+        var handlerStub = handlerMock.Object;
+
+        var messageRegistrationStub = new MessageRegistrationBuilder()
+            .WithHandlerInstanceType(handlerStub.GetType())
+            .WithMessageInstanceType(typeof(FooMessage))
+            .WithMessageType("foo")
+            .WithTopic("")
+            .Build();
+
+        var registry = new MessageHandlerRegistry();
+        registry.Register(messageRegistrationStub);
+
+        var sut = new ConsumerBuilder()
+            .WithUnitOfWork(new UnitOfWorkStub(handlerStub))
+            .WithMessageHandlerRegistry(registry)
+            .Build();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => sut.ConsumeSingle(cts.Token));
+    }
+
+    [Fact]
+    public async Task dead_letters_and_commits_when_handler_keeps_failing()
+    {
+        var handlerInvocations = 0;
+        var handler = new MessageHandlerSpy<FooMessage>(() =>
         {
-            _messageResult = messageResult;
-            _onGetNext = onGetNext;
+            handlerInvocations++;
+            throw new InvalidOperationException("boom");
+        });
+
+        var deadLetterQueueSpy = new DeadLetterQueueSpy();
+        var committed = false;
+
+        var sut = BuildConsumerWithHandler(
+            handler,
+            onCommit: _ =>
+            {
+                committed = true;
+                return Task.CompletedTask;
+            },
+            deadLetterQueue: deadLetterQueueSpy,
+            maxRetries: 2);
+
+        await sut.ConsumeSingle(CancellationToken.None);
+
+        Assert.Equal(3, handlerInvocations);
+        Assert.Equal(1, deadLetterQueueSpy.SendCount);
+        Assert.True(committed);
+    }
+
+    [Fact]
+    public async Task does_not_dead_letter_when_handler_eventually_succeeds()
+    {
+        var handlerInvocations = 0;
+        var handler = new MessageHandlerSpy<FooMessage>(() =>
+        {
+            handlerInvocations++;
+            if (handlerInvocations < 2)
+            {
+                throw new InvalidOperationException("boom");
+            }
+        });
+
+        var deadLetterQueueSpy = new DeadLetterQueueSpy();
+
+        var sut = BuildConsumerWithHandler(
+            handler,
+            deadLetterQueue: deadLetterQueueSpy,
+            maxRetries: 2);
+
+        await sut.ConsumeSingle(CancellationToken.None);
+
+        Assert.Equal(2, handlerInvocations);
+        Assert.Equal(0, deadLetterQueueSpy.SendCount);
+    }
+
+    [Fact]
+    public async Task propagates_exception_when_no_dead_letter_queue_is_configured()
+    {
+        var handler = new MessageHandlerSpy<FooMessage>(() => throw new InvalidOperationException("boom"));
+
+        var sut = BuildConsumerWithHandler(handler);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.ConsumeSingle(CancellationToken.None));
+    }
+
+    private static Consumer BuildConsumerWithHandler(
+        IMessageHandler<FooMessage> handler,
+        Func<CancellationToken, Task> onCommit = null,
+        IDeadLetterQueue deadLetterQueue = null,
+        int maxRetries = 0)
+    {
+        var registration = new MessageRegistrationBuilder()
+            .WithHandlerInstanceType(handler.GetType())
+            .WithMessageInstanceType(typeof(FooMessage))
+            .WithMessageType("foo")
+            .WithTopic("topic")
+            .Build();
+
+        var registry = new MessageHandlerRegistry();
+        registry.Register(registration);
+
+        var messageResult = new MessageResultBuilder()
+            .WithTransportLevelMessage(new TransportLevelMessageBuilder().WithType("foo").Build())
+            .WithTopic("topic")
+            .WithOnCommit(onCommit ?? (_ => Task.CompletedTask))
+            .Build();
+
+        var builder = new ConsumerBuilder()
+            .WithConsumerScopeFactory(new ConsumerScopeFactoryStub(new ConsumerScopeStub(messageResult)))
+            .WithUnitOfWork(new UnitOfWorkStub(handler))
+            .WithMessageHandlerRegistry(registry)
+            .WithMaxRetries(maxRetries);
+
+        if (deadLetterQueue != null)
+        {
+            builder.WithDeadLetterQueue(deadLetterQueue);
         }
 
-        public override Task<MessageResult> GetNext(CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            _onGetNext?.Invoke();
+        return builder.Build();
+    }
+    #region helper classes
 
-            return Task.FromResult(_messageResult);
+    private class ConsumerScopeDecoratorWithHooks : ConsumerScope
+    {
+        private readonly ConsumerScope _inner;
+        private readonly Action _preHook;
+        private readonly Action _postHook;
+
+        public ConsumerScopeDecoratorWithHooks(ConsumerScope inner, Action preHook = null, Action postHook = null)
+        {
+            _inner = inner;
+            _preHook = preHook;
+            _postHook = postHook;
+        }
+
+        public override async Task<MessageResult> GetNext(CancellationToken cancellationToken)
+        {
+            _preHook?.Invoke();
+            var result = await _inner.GetNext(cancellationToken);
+            _postHook?.Invoke();
+
+            return result;
         }
 
         public override void Dispose()
         {
-            Disposed++;
+            _inner.Dispose();
         }
-
-        public int Disposed { get; private set; }
     }
+
+    public class FooMessage
+    {
+        public string Value { get; set; }
+    }
+
+    private class DeadLetterQueueSpy : IDeadLetterQueue
+    {
+        public int SendCount { get; private set; }
+        public MessageResult LastMessage { get; private set; }
+        public Exception LastException { get; private set; }
+
+        public Task Send(MessageResult message, Exception exception, CancellationToken cancellationToken)
+        {
+            SendCount++;
+            LastMessage = message;
+            LastException = exception;
+            return Task.CompletedTask;
+        }
+    }
+
+    #endregion
+}
+
+internal class ConsumerScopeSpy : ConsumerScope
+{
+    private readonly MessageResult _messageResult;
+    private readonly Action _onGetNext;
+
+    public ConsumerScopeSpy(MessageResult messageResult, Action onGetNext = null)
+    {
+        _messageResult = messageResult;
+        _onGetNext = onGetNext;
+    }
+
+    public override Task<MessageResult> GetNext(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _onGetNext?.Invoke();
+
+        return Task.FromResult(_messageResult);
+    }
+
+    public override void Dispose()
+    {
+        Disposed++;
+    }
+
+    public int Disposed { get; private set; }
 }

--- a/src/Dafda.Tests/Consuming/TestConsumer.cs
+++ b/src/Dafda.Tests/Consuming/TestConsumer.cs
@@ -455,6 +455,20 @@ public class TestConsumer
         Assert.Equal(0, deadLetterQueueSpy.SendCount);
     }
 
+    [Fact]
+    public void disposing_consumer_disposes_the_dead_letter_queue()
+    {
+        var deadLetterQueueSpy = new DeadLetterQueueSpy();
+
+        var sut = BuildConsumerWithHandler(
+            new MessageHandlerSpy<FooMessage>(() => { }),
+            deadLetterQueue: deadLetterQueueSpy);
+
+        ((IDisposable)sut).Dispose();
+
+        Assert.Equal(1, deadLetterQueueSpy.DisposedCount);
+    }
+
     private static Consumer BuildConsumerWithHandler(
         IMessageHandler<FooMessage> handler,
         Func<CancellationToken, Task> onCommit = null,
@@ -525,11 +539,12 @@ public class TestConsumer
         public string Value { get; set; }
     }
 
-    private class DeadLetterQueueSpy : IDeadLetterQueue
+    private class DeadLetterQueueSpy : IDeadLetterQueue, IDisposable
     {
         public int SendCount { get; private set; }
         public MessageResult LastMessage { get; private set; }
         public Exception LastException { get; private set; }
+        public int DisposedCount { get; private set; }
 
         public Task Send(MessageResult message, Exception exception, CancellationToken cancellationToken)
         {
@@ -537,6 +552,11 @@ public class TestConsumer
             LastMessage = message;
             LastException = exception;
             return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            DisposedCount++;
         }
     }
 

--- a/src/Dafda.Tests/Consuming/TestKafkaDeadLetterQueue.cs
+++ b/src/Dafda.Tests/Consuming/TestKafkaDeadLetterQueue.cs
@@ -8,15 +8,23 @@ public class TestKafkaDeadLetterQueue
     [Fact]
     public void uses_configured_topic_name_when_provided()
     {
-        var topic = KafkaDeadLetterQueue.ResolveTopicName("orders.dead-letter", "orders");
+        var topic = KafkaDeadLetterQueue.ResolveTopicName("orders.dead-letter", "orders", "order-processor");
 
         Assert.Equal("orders.dead-letter", topic);
     }
 
     [Fact]
-    public void derives_topic_name_from_source_topic_when_not_provided()
+    public void derives_topic_name_from_source_topic_and_group_id_when_not_provided()
     {
-        var topic = KafkaDeadLetterQueue.ResolveTopicName(null, "orders");
+        var topic = KafkaDeadLetterQueue.ResolveTopicName(null, "orders", "order-processor");
+
+        Assert.Equal("orders.order-processor.dead-letter", topic);
+    }
+
+    [Fact]
+    public void derives_topic_name_from_source_topic_only_when_group_id_is_missing()
+    {
+        var topic = KafkaDeadLetterQueue.ResolveTopicName(null, "orders", null);
 
         Assert.Equal("orders.dead-letter", topic);
     }

--- a/src/Dafda.Tests/Consuming/TestKafkaDeadLetterQueue.cs
+++ b/src/Dafda.Tests/Consuming/TestKafkaDeadLetterQueue.cs
@@ -1,0 +1,23 @@
+namespace Dafda.Tests.Consuming;
+
+using Dafda.Consuming;
+using Xunit;
+
+public class TestKafkaDeadLetterQueue
+{
+    [Fact]
+    public void uses_configured_topic_name_when_provided()
+    {
+        var topic = KafkaDeadLetterQueue.ResolveTopicName("orders.dead-letter", "orders");
+
+        Assert.Equal("orders.dead-letter", topic);
+    }
+
+    [Fact]
+    public void derives_topic_name_from_source_topic_when_not_provided()
+    {
+        var topic = KafkaDeadLetterQueue.ResolveTopicName(null, "orders");
+
+        Assert.Equal("orders.dead-letter", topic);
+    }
+}

--- a/src/Dafda/Configuration/ConsumerConfiguration.cs
+++ b/src/Dafda/Configuration/ConsumerConfiguration.cs
@@ -1,20 +1,24 @@
+namespace Dafda.Configuration;
+
 using System;
 using System.Collections.Generic;
-using Dafda.Consuming;
-using Dafda.Consuming.Interfaces;
-using Dafda.Consuming.MessageFilters;
-
-namespace Dafda.Configuration;
+using Consuming;
+using Consuming.Interfaces;
+using Consuming.MessageFilters;
 
 internal class ConsumerConfiguration(
     IDictionary<string, string> configuration,
     MessageHandlerRegistry messageHandlerRegistry,
     ConsumerConfigurationFactories factories,
     MessageFilter messageFilter,
-    IConsumerErrorHandler consumerErrorHandler)
+    IConsumerErrorHandler consumerErrorHandler,
+    Func<IServiceProvider, IDeadLetterQueue> deadLetterQueueFactory,
+    int maxRetries)
     : ConsumerConfigurationBase(configuration, factories.UnitOfWorkFactory, consumerErrorHandler)
 {
     public ConsumerConfigurationFactories Factories { get; } = factories;
     public MessageHandlerRegistry MessageHandlerRegistry { get; } = messageHandlerRegistry;
     public MessageFilter MessageFilter { get; } = messageFilter;
+    public Func<IServiceProvider, IDeadLetterQueue> DeadLetterQueueFactory { get; } = deadLetterQueueFactory;
+    public int MaxRetries { get; } = maxRetries;
 }

--- a/src/Dafda/Configuration/ConsumerConfigurationBuilder.cs
+++ b/src/Dafda/Configuration/ConsumerConfigurationBuilder.cs
@@ -1,209 +1,239 @@
+namespace Dafda.Configuration;
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Dafda.Consuming;
-using Dafda.Consuming.MessageFilters;
+using Consuming;
+using Consuming.MessageFilters;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace Dafda.Configuration
+internal sealed class ConsumerConfigurationBuilder
 {
-    internal sealed class ConsumerConfigurationBuilder
+    private static readonly string[] DefaultConfigurationKeys =
     {
-        private static readonly string[] DefaultConfigurationKeys =
+        ConfigurationKey.GroupId,
+        ConfigurationKey.EnableAutoCommit,
+        ConfigurationKey.AllowAutoCreateTopics,
+        ConfigurationKey.BootstrapServers,
+        ConfigurationKey.BrokerVersionFallback,
+        ConfigurationKey.ApiVersionFallbackMs,
+        ConfigurationKey.SslCaLocation,
+        ConfigurationKey.SaslUsername,
+        ConfigurationKey.SaslPassword,
+        ConfigurationKey.SaslMechanisms,
+        ConfigurationKey.SecurityProtocol,
+    };
+
+    private static readonly string[] RequiredConfigurationKeys =
+    {
+        ConfigurationKey.GroupId,
+        ConfigurationKey.BootstrapServers
+    };
+
+    private readonly IDictionary<string, string> _configurations = new Dictionary<string, string>();
+    private readonly IList<NamingConvention> _namingConventions = new List<NamingConvention>();
+    private readonly MessageHandlerRegistry _messageHandlerRegistry = new MessageHandlerRegistry();
+
+    private ConfigurationSource _configurationSource = ConfigurationSource.Null;
+
+    private Func<IServiceProvider, IHandlerUnitOfWorkFactory> _handlerUnitOfWorkFactory;
+
+    private Func<IServiceProvider, IUnconfiguredMessageHandlingStrategy> _unconfiguredMessageHandlingStrategy;
+    private Func<IServiceProvider, IConsumerScopeFactory> _consumerScopeFactory;
+    private Func<IServiceProvider, IIncomingMessageFactory> _incomingMessageFactory = _ => new JsonIncomingMessageFactory();
+
+    private Func<IServiceProvider, IMessageHandlerExecutionStrategy> _messageHandlerExecutionStrategyFactory;
+    private bool _readFromBeginning;
+
+    private MessageFilter _messageFilter = MessageFilter.Default;
+    private ConsumerErrorHandler _consumerErrorHandler = ConsumerErrorHandler.Default;
+    private DeadLetterQueueOptions _deadLetterQueueOptions;
+
+    private void ApplyDefaults(IDictionary<string, string> configurations)
+    {
+        _handlerUnitOfWorkFactory ??= sp => ActivatorUtilities.CreateInstance<ServiceProviderUnitOfWorkFactory>(sp);
+        _unconfiguredMessageHandlingStrategy ??= sp => ActivatorUtilities.CreateInstance<RequireExplicitHandlers>(sp);
+        _messageHandlerExecutionStrategyFactory ??= sp => ActivatorUtilities.CreateInstance<DirectMessageHandlerExecutionStrategy>(sp);
+        _consumerScopeFactory ??= provider =>
         {
-            ConfigurationKey.GroupId,
-            ConfigurationKey.EnableAutoCommit,
-            ConfigurationKey.AllowAutoCreateTopics,
-            ConfigurationKey.BootstrapServers,
-            ConfigurationKey.BrokerVersionFallback,
-            ConfigurationKey.ApiVersionFallbackMs,
-            ConfigurationKey.SslCaLocation,
-            ConfigurationKey.SaslUsername,
-            ConfigurationKey.SaslPassword,
-            ConfigurationKey.SaslMechanisms,
-            ConfigurationKey.SecurityProtocol,
-        };
+            var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
 
-        private static readonly string[] RequiredConfigurationKeys =
-        {
-            ConfigurationKey.GroupId,
-            ConfigurationKey.BootstrapServers
-        };
-
-        private readonly IDictionary<string, string> _configurations = new Dictionary<string, string>();
-        private readonly IList<NamingConvention> _namingConventions = new List<NamingConvention>();
-        private readonly MessageHandlerRegistry _messageHandlerRegistry = new MessageHandlerRegistry();
-
-        private ConfigurationSource _configurationSource = ConfigurationSource.Null;
-
-        private Func<IServiceProvider, IHandlerUnitOfWorkFactory> _handlerUnitOfWorkFactory;
-
-        private Func<IServiceProvider, IUnconfiguredMessageHandlingStrategy> _unconfiguredMessageHandlingStrategy;
-        private Func<IServiceProvider, IConsumerScopeFactory> _consumerScopeFactory;
-        private Func<IServiceProvider, IIncomingMessageFactory> _incomingMessageFactory = _ => new JsonIncomingMessageFactory();
-
-        private Func<IServiceProvider, IMessageHandlerExecutionStrategy> _messageHandlerExecutionStrategyFactory;
-        private bool _readFromBeginning;
-
-        private MessageFilter _messageFilter = MessageFilter.Default;
-        private ConsumerErrorHandler _consumerErrorHandler = ConsumerErrorHandler.Default;
-
-        private void ApplyDefaults(IDictionary<string, string> configurations)
-        {
-            _handlerUnitOfWorkFactory ??= sp => ActivatorUtilities.CreateInstance<ServiceProviderUnitOfWorkFactory>(sp);
-            _unconfiguredMessageHandlingStrategy ??= sp => ActivatorUtilities.CreateInstance<RequireExplicitHandlers>(sp);
-            _messageHandlerExecutionStrategyFactory ??= sp => ActivatorUtilities.CreateInstance<DirectMessageHandlerExecutionStrategy>(sp);
-            _consumerScopeFactory ??= provider =>
-            {
-                var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
-
-                return new KafkaBasedConsumerScopeFactory(
-                    loggerFactory: loggerFactory,
-                    configuration: configurations,
-                    topics: _messageHandlerRegistry.GetAllSubscribedTopics(),
-                    incomingMessageFactory: _incomingMessageFactory(provider),
-                    readFromBeginning: _readFromBeginning
-                );
-            };
-        }
-
-        public ConsumerConfigurationBuilder WithConfigurationSource(ConfigurationSource configurationSource)
-        {
-            _configurationSource = configurationSource;
-            return this;
-        }
-
-        public ConsumerConfigurationBuilder WithNamingConvention(Func<string, string> converter)
-        {
-            _namingConventions.Add(NamingConvention.UseCustom(converter));
-            return this;
-        }
-
-        internal ConsumerConfigurationBuilder WithNamingConvention(NamingConvention namingConvention)
-        {
-            _namingConventions.Add(namingConvention);
-            return this;
-        }
-
-        public ConsumerConfigurationBuilder WithEnvironmentStyle(string prefix = null, params string[] additionalPrefixes)
-        {
-            WithNamingConvention(NamingConvention.UseEnvironmentStyle(prefix));
-
-            foreach (var additionalPrefix in additionalPrefixes)
-            {
-                WithNamingConvention(NamingConvention.UseEnvironmentStyle(additionalPrefix));
-            }
-
-            return this;
-        }
-
-        public ConsumerConfigurationBuilder WithConfiguration(string key, string value)
-        {
-            _configurations[key] = value;
-            return this;
-        }
-
-        public ConsumerConfigurationBuilder WithGroupId(string groupId)
-        {
-            return WithConfiguration(ConfigurationKey.GroupId, groupId);
-        }
-
-        public ConsumerConfigurationBuilder WithBootstrapServers(string bootstrapServers)
-        {
-            return WithConfiguration(ConfigurationKey.BootstrapServers, bootstrapServers);
-        }
-
-        public ConsumerConfigurationBuilder WithUnitOfWorkFactory(Func<IServiceProvider, IHandlerUnitOfWorkFactory> handlerUnitOfWorkFactory)
-        {
-            _handlerUnitOfWorkFactory = handlerUnitOfWorkFactory;
-            return this;
-        }
-
-        internal ConsumerConfigurationBuilder WithConsumerScopeFactory(Func<IServiceProvider, IConsumerScopeFactory> consumerScopeFactory)
-        {
-            _consumerScopeFactory = consumerScopeFactory;
-            return this;
-        }
-
-        public ConsumerConfigurationBuilder WithUnconfiguredMessageHandlingStrategy(Func<IServiceProvider, IUnconfiguredMessageHandlingStrategy> unconfiguredMessageHandlingStrategy)
-        {
-            _unconfiguredMessageHandlingStrategy = unconfiguredMessageHandlingStrategy;
-            return this;
-        }
-        
-        public ConsumerConfigurationBuilder ReadFromBeginning()
-        {
-            _readFromBeginning = true;
-            return this;
-        }
-
-        public void WithMessageFilter(MessageFilter messageFilter)
-        {
-            _messageFilter = messageFilter;
-        }
-
-        public ConsumerConfigurationBuilder RegisterMessageHandler<TMessage, TMessageHandler>(string topic, string messageType)
-            where TMessageHandler : IMessageHandler<TMessage>
-        {
-            _messageHandlerRegistry.Register<TMessage, TMessageHandler>(topic, messageType);
-            return this;
-        }
-
-        public ConsumerConfigurationBuilder WithIncomingMessageFactory(Func<IServiceProvider, IIncomingMessageFactory> incomingMessageFactory)
-        {
-            _incomingMessageFactory = incomingMessageFactory;
-            return this;
-        }
-
-        public ConsumerConfigurationBuilder WithPoisonMessageHandling()
-        {
-            var inner = _incomingMessageFactory;
-            _incomingMessageFactory = provider => new PoisonAwareIncomingMessageFactory(
-                provider.GetRequiredService<ILogger<PoisonAwareIncomingMessageFactory>>(),
-                inner(provider)
-            );
-            return this;
-        }
-
-        public ConsumerConfigurationBuilder WithConsumerErrorHandler(Func<Exception, Task<ConsumerFailureStrategy>> failureEvaluation)
-        {
-            _consumerErrorHandler = new ConsumerErrorHandler(failureEvaluation);
-            return this;
-        }
-
-        public ConsumerConfigurationBuilder WithMessageHandlerExecutionStrategyFactory(Func<IServiceProvider, IMessageHandlerExecutionStrategy> factory)
-        {
-            _messageHandlerExecutionStrategyFactory = factory;
-            return this;
-        }
-
-        internal ConsumerConfiguration Build()
-        {
-            var configurations = new ConfigurationBuilder()
-                .WithConfigurationKeys(DefaultConfigurationKeys)
-                .WithRequiredConfigurationKeys(RequiredConfigurationKeys)
-                .WithNamingConventions(_namingConventions.ToArray())
-                .WithConfigurationSource(_configurationSource)
-                .WithConfigurations(_configurations)
-                .Build();
-            
-            ApplyDefaults(configurations);
-
-            var consumerConfigurationFactories = new ConsumerConfigurationFactories(
-                UnitOfWorkFactory: _handlerUnitOfWorkFactory,
-                UnconfiguredMessageHandlingStrategy: _unconfiguredMessageHandlingStrategy,
-                ConsumerScopeFactory: _consumerScopeFactory,
-                IncomingMessageFactory: _incomingMessageFactory,
-                MessageHandlerExecutionStrategyFactory: _messageHandlerExecutionStrategyFactory);
-            
-            return new ConsumerConfiguration(
+            return new KafkaBasedConsumerScopeFactory(
+                loggerFactory: loggerFactory,
                 configuration: configurations,
-                messageHandlerRegistry: _messageHandlerRegistry,
-                factories: consumerConfigurationFactories,
-                messageFilter: _messageFilter,
-                consumerErrorHandler: _consumerErrorHandler);
+                topics: _messageHandlerRegistry.GetAllSubscribedTopics(),
+                incomingMessageFactory: _incomingMessageFactory(provider),
+                readFromBeginning: _readFromBeginning
+            );
+        };
+    }
+
+    public ConsumerConfigurationBuilder WithConfigurationSource(ConfigurationSource configurationSource)
+    {
+        _configurationSource = configurationSource;
+        return this;
+    }
+
+    public ConsumerConfigurationBuilder WithNamingConvention(Func<string, string> converter)
+    {
+        _namingConventions.Add(NamingConvention.UseCustom(converter));
+        return this;
+    }
+
+    internal ConsumerConfigurationBuilder WithNamingConvention(NamingConvention namingConvention)
+    {
+        _namingConventions.Add(namingConvention);
+        return this;
+    }
+
+    public ConsumerConfigurationBuilder WithEnvironmentStyle(string prefix = null, params string[] additionalPrefixes)
+    {
+        WithNamingConvention(NamingConvention.UseEnvironmentStyle(prefix));
+
+        foreach (var additionalPrefix in additionalPrefixes)
+        {
+            WithNamingConvention(NamingConvention.UseEnvironmentStyle(additionalPrefix));
         }
+
+        return this;
+    }
+
+    public ConsumerConfigurationBuilder WithConfiguration(string key, string value)
+    {
+        _configurations[key] = value;
+        return this;
+    }
+
+    public ConsumerConfigurationBuilder WithGroupId(string groupId)
+    {
+        return WithConfiguration(ConfigurationKey.GroupId, groupId);
+    }
+
+    public ConsumerConfigurationBuilder WithBootstrapServers(string bootstrapServers)
+    {
+        return WithConfiguration(ConfigurationKey.BootstrapServers, bootstrapServers);
+    }
+
+    public ConsumerConfigurationBuilder WithUnitOfWorkFactory(Func<IServiceProvider, IHandlerUnitOfWorkFactory> handlerUnitOfWorkFactory)
+    {
+        _handlerUnitOfWorkFactory = handlerUnitOfWorkFactory;
+        return this;
+    }
+
+    internal ConsumerConfigurationBuilder WithConsumerScopeFactory(Func<IServiceProvider, IConsumerScopeFactory> consumerScopeFactory)
+    {
+        _consumerScopeFactory = consumerScopeFactory;
+        return this;
+    }
+
+    public ConsumerConfigurationBuilder WithUnconfiguredMessageHandlingStrategy(Func<IServiceProvider, IUnconfiguredMessageHandlingStrategy> unconfiguredMessageHandlingStrategy)
+    {
+        _unconfiguredMessageHandlingStrategy = unconfiguredMessageHandlingStrategy;
+        return this;
+    }
+        
+    public ConsumerConfigurationBuilder ReadFromBeginning()
+    {
+        _readFromBeginning = true;
+        return this;
+    }
+
+    public void WithMessageFilter(MessageFilter messageFilter)
+    {
+        _messageFilter = messageFilter;
+    }
+
+    public ConsumerConfigurationBuilder RegisterMessageHandler<TMessage, TMessageHandler>(string topic, string messageType)
+        where TMessageHandler : IMessageHandler<TMessage>
+    {
+        _messageHandlerRegistry.Register<TMessage, TMessageHandler>(topic, messageType);
+        return this;
+    }
+
+    public ConsumerConfigurationBuilder WithIncomingMessageFactory(Func<IServiceProvider, IIncomingMessageFactory> incomingMessageFactory)
+    {
+        _incomingMessageFactory = incomingMessageFactory;
+        return this;
+    }
+
+    public ConsumerConfigurationBuilder WithPoisonMessageHandling()
+    {
+        var inner = _incomingMessageFactory;
+        _incomingMessageFactory = provider => new PoisonAwareIncomingMessageFactory(
+            provider.GetRequiredService<ILogger<PoisonAwareIncomingMessageFactory>>(),
+            inner(provider)
+        );
+        return this;
+    }
+
+    public ConsumerConfigurationBuilder WithConsumerErrorHandler(Func<Exception, Task<ConsumerFailureStrategy>> failureEvaluation)
+    {
+        _consumerErrorHandler = new ConsumerErrorHandler(failureEvaluation);
+        return this;
+    }
+
+    public ConsumerConfigurationBuilder WithMessageHandlerExecutionStrategyFactory(Func<IServiceProvider, IMessageHandlerExecutionStrategy> factory)
+    {
+        _messageHandlerExecutionStrategyFactory = factory;
+        return this;
+    }
+
+    public DeadLetterQueueOptions WithDeadLetterQueue(string topicName = null)
+    {
+        _deadLetterQueueOptions = new DeadLetterQueueOptions(topicName);
+        return _deadLetterQueueOptions;
+    }
+
+    internal ConsumerConfiguration Build()
+    {
+        var configurations = new ConfigurationBuilder()
+            .WithConfigurationKeys(DefaultConfigurationKeys)
+            .WithRequiredConfigurationKeys(RequiredConfigurationKeys)
+            .WithNamingConventions(_namingConventions.ToArray())
+            .WithConfigurationSource(_configurationSource)
+            .WithConfigurations(_configurations)
+            .Build();
+            
+        ApplyDefaults(configurations);
+
+        var consumerConfigurationFactories = new ConsumerConfigurationFactories(
+            UnitOfWorkFactory: _handlerUnitOfWorkFactory,
+            UnconfiguredMessageHandlingStrategy: _unconfiguredMessageHandlingStrategy,
+            ConsumerScopeFactory: _consumerScopeFactory,
+            IncomingMessageFactory: _incomingMessageFactory,
+            MessageHandlerExecutionStrategyFactory: _messageHandlerExecutionStrategyFactory);
+
+        var deadLetterQueueFactory = BuildDeadLetterQueueFactory(configurations);
+        var maxRetries = _deadLetterQueueOptions?.MaxRetries ?? 0;
+
+        return new ConsumerConfiguration(
+            configuration: configurations,
+            messageHandlerRegistry: _messageHandlerRegistry,
+            factories: consumerConfigurationFactories,
+            messageFilter: _messageFilter,
+            consumerErrorHandler: _consumerErrorHandler,
+            deadLetterQueueFactory: deadLetterQueueFactory,
+            maxRetries: maxRetries);
+    }
+
+    private Func<IServiceProvider, IDeadLetterQueue> BuildDeadLetterQueueFactory(IDictionary<string, string> configurations)
+    {
+        if (_deadLetterQueueOptions == null)
+        {
+            return _ => NullDeadLetterQueue.Instance;
+        }
+
+        var topicName = _deadLetterQueueOptions.TopicName;
+        
+        var producerConfiguration = configurations
+            .Where(pair => ConfigurationKey.GetAllProducerKeys().Any(key => key.ToString() == pair.Key))
+            .ToDictionary(pair => pair.Key, pair => pair.Value);
+
+        return provider => new KafkaDeadLetterQueue(
+            provider.GetRequiredService<ILoggerFactory>(),
+            producerConfiguration,
+            topicName);
     }
 }

--- a/src/Dafda/Configuration/ConsumerOptions.cs
+++ b/src/Dafda/Configuration/ConsumerOptions.cs
@@ -1,10 +1,11 @@
+namespace Dafda.Configuration;
+
 using System;
 using System.Threading.Tasks;
-using Dafda.Consuming;
-using Dafda.Consuming.MessageFilters;
+using Consuming;
+using Consuming.MessageFilters;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Dafda.Configuration;
 
 /// <summary>
 /// Facilitates Dafda configuration in .NET applications using the <see cref="IServiceCollection"/>.
@@ -227,6 +228,26 @@ public sealed class ConsumerOptions
         Func<IServiceProvider, IMessageHandlerExecutionStrategy> factory)
     {
         Builder.WithMessageHandlerExecutionStrategyFactory(factory);
+    }
+
+    /// <summary>
+    /// Enable a dead letter queue for this consumer. When a message handler fails
+    /// (after any configured retries are exhausted), the original message is
+    /// published to the dead letter topic and the offset is committed so the
+    /// consumer can continue past the poison message.
+    /// </summary>
+    /// <param name="topicName">
+    /// The dead letter topic name. When omitted, the topic is derived from the
+    /// source topic of the failed message (e.g. <c>orders</c> becomes
+    /// <c>orders.dead-letter</c>).
+    /// </param>
+    /// <returns>
+    /// A <see cref="DeadLetterQueueOptions"/> to further configure the dead letter
+    /// queue, e.g. <c>WithMaxRetries(...)</c>.
+    /// </returns>
+    public DeadLetterQueueOptions WithDeadLetterQueue(string topicName = null)
+    {
+        return Builder.WithDeadLetterQueue(topicName);
     }
 
     private class DefaultConfigurationSource(Microsoft.Extensions.Configuration.IConfiguration configuration)

--- a/src/Dafda/Configuration/ConsumerServiceCollectionExtensions.cs
+++ b/src/Dafda/Configuration/ConsumerServiceCollectionExtensions.cs
@@ -44,7 +44,9 @@ public static class ConsumerServiceCollectionExtensions
                 configuration.Factories.UnconfiguredMessageHandlingStrategy(provider),
                 configuration.MessageFilter,
                 configuration.Factories.MessageHandlerExecutionStrategyFactory(provider),
-                configuration.EnableAutoCommit
+                configuration.EnableAutoCommit,
+                configuration.DeadLetterQueueFactory(provider),
+                configuration.MaxRetries
             ),
             configuration.GroupId,
             configuration.ConsumerErrorHandler
@@ -78,7 +80,9 @@ public static class ConsumerServiceCollectionExtensions
                     configuration.Factories.UnconfiguredMessageHandlingStrategy(provider),
                     configuration.MessageFilter,
                     configuration.Factories.MessageHandlerExecutionStrategyFactory(provider),
-                    configuration.EnableAutoCommit
+                    configuration.EnableAutoCommit,
+                    configuration.DeadLetterQueueFactory(provider),
+                    configuration.MaxRetries
                 ),
                 configuration.GroupId,
                 configuration.ConsumerErrorHandler

--- a/src/Dafda/Configuration/DeadLetterQueueOptions.cs
+++ b/src/Dafda/Configuration/DeadLetterQueueOptions.cs
@@ -1,0 +1,41 @@
+namespace Dafda.Configuration;
+
+/// <summary>
+/// Fluent options for configuring a dead letter queue on a consumer.
+/// Returned by <see cref="ConsumerOptions.WithDeadLetterQueue"/>.
+/// </summary>
+public sealed class DeadLetterQueueOptions
+{
+    internal DeadLetterQueueOptions(string topicName)
+    {
+        TopicName = topicName;
+    }
+
+    /// <summary>
+    /// The explicit dead letter topic name. When <c>null</c>, the topic is
+    /// derived from the source topic of the failed message.
+    /// </summary>
+    internal string TopicName { get; }
+
+    /// <summary>
+    /// The number of additional delivery attempts after the first failure,
+    /// before the message is forwarded to the dead letter queue.
+    /// </summary>
+    internal int MaxRetries { get; private set; }
+
+    /// <summary>
+    /// Set the maximum number of retries (additional attempts after the first
+    /// delivery) before a failing message is sent to the dead letter queue.
+    /// </summary>
+    /// <param name="maxRetries">The number of retries. Must be zero or greater.</param>
+    public DeadLetterQueueOptions WithMaxRetries(int maxRetries)
+    {
+        if (maxRetries < 0)
+        {
+            throw new InvalidConfigurationException("The number of retries for a dead letter queue cannot be negative.");
+        }
+
+        MaxRetries = maxRetries;
+        return this;
+    }
+}

--- a/src/Dafda/Consuming/Consumer.cs
+++ b/src/Dafda/Consuming/Consumer.cs
@@ -1,73 +1,84 @@
+namespace Dafda.Consuming;
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Dafda.Consuming.Interfaces;
-using Dafda.Consuming.MessageFilters;
-using Dafda.Diagnostics;
+using Diagnostics;
+using Interfaces;
+using MessageFilters;
 
-namespace Dafda.Consuming
+internal class Consumer(
+    MessageHandlerRegistry messageHandlerRegistry,
+    IHandlerUnitOfWorkFactory unitOfWorkFactory,
+    IConsumerScopeFactory consumerScopeFactory,
+    IUnconfiguredMessageHandlingStrategy fallbackHandler,
+    MessageFilter messageFilter,
+    IMessageHandlerExecutionStrategy messageHandlerExecutionStrategy,
+    bool isAutoCommitEnabled = false,
+    IDeadLetterQueue deadLetterQueue = null,
+    int maxRetries = 0)
+    : IConsumer
 {
-    internal class Consumer : IConsumer
+    private readonly LocalMessageDispatcher _localMessageDispatcher = new(
+        messageHandlerRegistry,
+        unitOfWorkFactory,
+        fallbackHandler,
+        messageHandlerExecutionStrategy);
+
+    private readonly IDeadLetterQueue _deadLetterQueue = deadLetterQueue ?? NullDeadLetterQueue.Instance;
+
+    public async Task ConsumeAll(CancellationToken cancellationToken)
     {
-        private readonly LocalMessageDispatcher _localMessageDispatcher;
-        private readonly IConsumerScopeFactory _consumerScopeFactory;
-        private readonly MessageFilter _messageFilter;
-        private readonly bool _isAutoCommitEnabled;
-
-        public Consumer(
-            MessageHandlerRegistry messageHandlerRegistry,
-            IHandlerUnitOfWorkFactory unitOfWorkFactory,
-            IConsumerScopeFactory consumerScopeFactory,
-            IUnconfiguredMessageHandlingStrategy fallbackHandler,
-            MessageFilter messageFilter,
-            IMessageHandlerExecutionStrategy messageHandlerExecutionStrategy,
-            bool isAutoCommitEnabled = false)
+        using var consumerScope = consumerScopeFactory.CreateConsumerScope();
+        while (!cancellationToken.IsCancellationRequested)
         {
-            _localMessageDispatcher =
-                new LocalMessageDispatcher(
-                    messageHandlerRegistry,
-                    unitOfWorkFactory,
-                    fallbackHandler,
-                    messageHandlerExecutionStrategy);
-            _consumerScopeFactory =
-                consumerScopeFactory
-                ?? throw new ArgumentNullException(nameof(consumerScopeFactory));
-            _messageFilter = messageFilter;
-            _isAutoCommitEnabled = isAutoCommitEnabled;
+            await ProcessNextMessage(consumerScope, cancellationToken);
+        }
+    }
+
+    public async Task ConsumeSingle(CancellationToken cancellationToken)
+    {
+        using var consumerScope = consumerScopeFactory.CreateConsumerScope();
+        await ProcessNextMessage(consumerScope, cancellationToken);
+    }
+
+    private async Task ProcessNextMessage(ConsumerScope consumerScope, CancellationToken cancellationToken)
+    {
+        var messageResult = await consumerScope.GetNext(cancellationToken);
+        using var activity = DafdaActivitySource.StartReceivingActivity(messageResult);
+
+        if (messageFilter.CanAcceptMessage(messageResult))
+        {
+            await Dispatch(messageResult, cancellationToken);
         }
 
-        public async Task ConsumeAll(CancellationToken cancellationToken)
+        if (!isAutoCommitEnabled)
         {
-            using (var consumerScope = _consumerScopeFactory.CreateConsumerScope())
-            {
-                while (!cancellationToken.IsCancellationRequested)
-                {
-                    await ProcessNextMessage(consumerScope, cancellationToken);
-                }
-            }
+            await messageResult.Commit(cancellationToken);
         }
+    }
 
-        public async Task ConsumeSingle(CancellationToken cancellationToken)
+    private async Task Dispatch(MessageResult messageResult, CancellationToken cancellationToken)
+    {
+        var deadLetterQueueEnabled = _deadLetterQueue is not NullDeadLetterQueue;
+        var attempt = 0;
+
+        while (true)
         {
-            using (var consumerScope = _consumerScopeFactory.CreateConsumerScope())
-            {
-                await ProcessNextMessage(consumerScope, cancellationToken);
-            }
-        }
-
-        private async Task ProcessNextMessage(ConsumerScope consumerScope, CancellationToken cancellationToken)
-        {
-            var messageResult = await consumerScope.GetNext(cancellationToken);
-            using var activity = DafdaActivitySource.StartReceivingActivity(messageResult);
-
-            if (_messageFilter.CanAcceptMessage(messageResult))
+            try
             {
                 await _localMessageDispatcher.Dispatch(messageResult, cancellationToken);
+                return;
             }
-
-            if (!_isAutoCommitEnabled)
+            catch (Exception exception) when (deadLetterQueueEnabled)
             {
-                await messageResult.Commit(cancellationToken);
+                if (attempt++ < maxRetries)
+                {
+                    continue;
+                }
+
+                await _deadLetterQueue.Send(messageResult, exception, cancellationToken);
+                return;
             }
         }
     }

--- a/src/Dafda/Consuming/Consumer.cs
+++ b/src/Dafda/Consuming/Consumer.cs
@@ -70,7 +70,7 @@ internal class Consumer(
                 await _localMessageDispatcher.Dispatch(messageResult, cancellationToken);
                 return;
             }
-            catch (Exception exception) when (deadLetterQueueEnabled)
+            catch (Exception exception) when (deadLetterQueueEnabled && !cancellationToken.IsCancellationRequested)
             {
                 if (attempt++ < maxRetries)
                 {

--- a/src/Dafda/Consuming/Consumer.cs
+++ b/src/Dafda/Consuming/Consumer.cs
@@ -17,7 +17,7 @@ internal class Consumer(
     bool isAutoCommitEnabled = false,
     IDeadLetterQueue deadLetterQueue = null,
     int maxRetries = 0)
-    : IConsumer
+    : IConsumer, IDisposable
 {
     private readonly LocalMessageDispatcher _localMessageDispatcher = new(
         messageHandlerRegistry,
@@ -81,5 +81,10 @@ internal class Consumer(
                 return;
             }
         }
+    }
+
+    public void Dispose()
+    {
+        (_deadLetterQueue as IDisposable)?.Dispose();
     }
 }

--- a/src/Dafda/Consuming/ConsumerHostedService.cs
+++ b/src/Dafda/Consuming/ConsumerHostedService.cs
@@ -61,5 +61,12 @@ namespace Dafda.Consuming
         {
             return Task.Run(async () => { await ConsumeAll(stoppingToken); }, stoppingToken);
         }
+
+        /// <summary>Disposes the underlying consumer (and any resources it owns, such as a dead letter queue producer).</summary>
+        public override void Dispose()
+        {
+            (_consumer as IDisposable)?.Dispose();
+            base.Dispose();
+        }
     }
 }

--- a/src/Dafda/Consuming/IDeadLetterQueue.cs
+++ b/src/Dafda/Consuming/IDeadLetterQueue.cs
@@ -1,0 +1,17 @@
+namespace Dafda.Consuming;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Forwards a message that could not be handled (after retries are exhausted)
+/// to a dead letter queue, so the consumer can move past the poison message.
+/// </summary>
+internal interface IDeadLetterQueue
+{
+    /// <summary>
+    /// Publish the failed <paramref name="message"/> to the dead letter queue.
+    /// </summary>
+    Task Send(MessageResult message, Exception exception, CancellationToken cancellationToken);
+}

--- a/src/Dafda/Consuming/KafkaConsumerScope.cs
+++ b/src/Dafda/Consuming/KafkaConsumerScope.cs
@@ -1,53 +1,53 @@
+namespace Dafda.Consuming;
+
 using System.Threading;
 using System.Threading.Tasks;
 using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
 
-namespace Dafda.Consuming
+internal class KafkaConsumerScope : ConsumerScope
 {
-    internal class KafkaConsumerScope : ConsumerScope
+    private readonly ILogger<KafkaConsumerScope> _logger;
+    private readonly IConsumer<string, string> _innerKafkaConsumer;
+    private readonly IIncomingMessageFactory _incomingMessageFactory;
+    private readonly string _groupId;
+
+    internal KafkaConsumerScope(ILoggerFactory loggerFactory, IConsumer<string, string> innerKafkaConsumer, IIncomingMessageFactory incomingMessageFactory, string groupId)
     {
-        private readonly ILogger<KafkaConsumerScope> _logger;
-        private readonly IConsumer<string, string> _innerKafkaConsumer;
-        private readonly IIncomingMessageFactory _incomingMessageFactory;
-        private readonly string _groupId;
+        _logger = loggerFactory.CreateLogger<KafkaConsumerScope>();
+        _innerKafkaConsumer = innerKafkaConsumer;
+        _incomingMessageFactory = incomingMessageFactory;
+        _groupId = groupId;
+    }
 
-        internal KafkaConsumerScope(ILoggerFactory loggerFactory, IConsumer<string, string> innerKafkaConsumer, IIncomingMessageFactory incomingMessageFactory, string groupId)
-        {
-            _logger = loggerFactory.CreateLogger<KafkaConsumerScope>();
-            _innerKafkaConsumer = innerKafkaConsumer;
-            _incomingMessageFactory = incomingMessageFactory;
-            _groupId = groupId;
-        }
+    public override Task<MessageResult> GetNext(CancellationToken cancellationToken)
+    {
+        var innerResult = _innerKafkaConsumer.Consume(cancellationToken);
 
-        public override Task<MessageResult> GetNext(CancellationToken cancellationToken)
-        {
-            var innerResult = _innerKafkaConsumer.Consume(cancellationToken);
-
-            _logger.LogDebug("Received message {Key}: {RawMessage}", innerResult.Message?.Key, innerResult.Message?.Value);
-            var result = new MessageResult(
-                message: _incomingMessageFactory.Create(innerResult.Message.Value),
-                onCommit: (CancellationToken cancellationToken) =>
-                {
-                    _innerKafkaConsumer.Commit(innerResult);
-                    return Task.CompletedTask;
-                })
+        _logger.LogDebug("Received message {Key}: {RawMessage}", innerResult.Message?.Key, innerResult.Message?.Value);
+        var result = new MessageResult(
+            message: _incomingMessageFactory.Create(innerResult.Message.Value),
+            onCommit: _ =>
             {
-
-                Topic = innerResult.Topic,
-                Partition = innerResult.Partition.Value,
-                PartitionKey = innerResult.Message.Key,
-                ClientId = _innerKafkaConsumer.Name,
-                GroupId = _groupId
-            };
-
-            return Task.FromResult(result);
-        }
-
-        public override void Dispose()
+                _innerKafkaConsumer.Commit(innerResult);
+                return Task.CompletedTask;
+            })
         {
-            _innerKafkaConsumer.Close();
-            _innerKafkaConsumer.Dispose();
-        }
+
+            Topic = innerResult.Topic,
+            RawMessage = innerResult.Message.Value,
+            Partition = innerResult.Partition.Value,
+            PartitionKey = innerResult.Message.Key,
+            ClientId = _innerKafkaConsumer.Name,
+            GroupId = _groupId
+        };
+
+        return Task.FromResult(result);
+    }
+
+    public override void Dispose()
+    {
+        _innerKafkaConsumer.Close();
+        _innerKafkaConsumer.Dispose();
     }
 }

--- a/src/Dafda/Consuming/KafkaDeadLetterQueue.cs
+++ b/src/Dafda/Consuming/KafkaDeadLetterQueue.cs
@@ -1,0 +1,76 @@
+namespace Dafda.Consuming;
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Publishes failed messages to a Kafka dead letter topic. When no explicit
+/// topic name is configured, the target topic is derived from the source
+/// topic of the message using the <see cref="DefaultTopicSuffix"/>.
+/// </summary>
+internal sealed class KafkaDeadLetterQueue(
+    ILoggerFactory loggerFactory,
+    IEnumerable<KeyValuePair<string, string>> configuration,
+    string topicName)
+    : IDeadLetterQueue, IDisposable
+{
+    private const string DefaultTopicSuffix = ".dead-letter";
+
+    private readonly ILogger<KafkaDeadLetterQueue> _logger = loggerFactory.CreateLogger<KafkaDeadLetterQueue>();
+    private readonly IProducer<string, string> _producer = new ProducerBuilder<string, string>(configuration).Build();
+
+    private string ResolveTopic(MessageResult message)
+    {
+        return ResolveTopicName(topicName, message.Topic);
+    }
+
+    internal static string ResolveTopicName(string configuredTopicName, string sourceTopic)
+    {
+        return configuredTopicName ?? $"{sourceTopic}{DefaultTopicSuffix}";
+    }
+
+    public async Task Send(MessageResult message, Exception exception, CancellationToken cancellationToken)
+    {
+        var topic = ResolveTopic(message);
+
+        _logger.LogWarning(
+            exception,
+            "Dead-lettering message with key {Key} from topic {SourceTopic} to {DeadLetterTopic}",
+            message.PartitionKey,
+            message.Topic,
+            topic);
+
+        var headers = new Headers
+        {
+            { "dafda-dead-letter-source-topic", Encode(message.Topic) },
+            { "dafda-dead-letter-exception-type", Encode(exception.GetType().FullName) },
+            { "dafda-dead-letter-exception-message", Encode(exception.Message) },
+            { "dafda-dead-letter-timestamp", Encode(DateTimeOffset.UtcNow.ToString("O")) },
+        };
+
+        await _producer.ProduceAsync(
+            topic: topic,
+            message: new Message<string, string>
+            {
+                Key = message.PartitionKey,
+                Value = message.RawMessage,
+                Headers = headers
+            },
+            cancellationToken);
+    }
+
+    private static byte[] Encode(string value)
+    {
+        return Encoding.UTF8.GetBytes(value ?? string.Empty);
+    }
+
+    public void Dispose()
+    {
+        _producer?.Dispose();
+    }
+}

--- a/src/Dafda/Consuming/KafkaDeadLetterQueue.cs
+++ b/src/Dafda/Consuming/KafkaDeadLetterQueue.cs
@@ -26,12 +26,19 @@ internal sealed class KafkaDeadLetterQueue(
 
     private string ResolveTopic(MessageResult message)
     {
-        return ResolveTopicName(topicName, message.Topic);
+        return ResolveTopicName(topicName, message.Topic, message.GroupId);
     }
 
-    internal static string ResolveTopicName(string configuredTopicName, string sourceTopic)
+    internal static string ResolveTopicName(string configuredTopicName, string sourceTopic, string groupId)
     {
-        return configuredTopicName ?? $"{sourceTopic}{DefaultTopicSuffix}";
+        if (configuredTopicName != null)
+        {
+            return configuredTopicName;
+        }
+
+        return string.IsNullOrEmpty(groupId)
+            ? $"{sourceTopic}{DefaultTopicSuffix}"
+            : $"{sourceTopic}.{groupId}{DefaultTopicSuffix}";
     }
 
     public async Task Send(MessageResult message, Exception exception, CancellationToken cancellationToken)

--- a/src/Dafda/Consuming/MessageResult.cs
+++ b/src/Dafda/Consuming/MessageResult.cs
@@ -1,48 +1,53 @@
+namespace Dafda.Consuming;
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Dafda.Consuming
+/// <summary>
+/// Object that contains message when consumed from Kafka.
+/// To be used for message handling prior to dispatching to the handlers.
+/// </summary>
+public class MessageResult
 {
+    private static readonly Func<CancellationToken, Task> EmptyCommitAction = (_) => Task.CompletedTask;
+    private readonly Func<CancellationToken, Task> _onCommit;
+
     /// <summary>
-    /// Object that contains message when consumed from Kafka.
-    /// To be used for message handling prior to dispatching to the handlers.
+    /// Resulting Message contaning Transport Level Message
     /// </summary>
-    public class MessageResult
+    public MessageResult(TransportLevelMessage message, Func<CancellationToken, Task> onCommit = null)
     {
-        private static readonly Func<CancellationToken, Task> EmptyCommitAction = (_) => Task.CompletedTask;
-        private readonly Func<CancellationToken, Task> _onCommit;
+        Message = message;
+        _onCommit = onCommit ?? EmptyCommitAction;
+    }
 
-        /// <summary>
-        /// Resulting Message contaning Transport Level Message
-        /// </summary>
-        public MessageResult(TransportLevelMessage message, Func<CancellationToken, Task> onCommit = null)
-        {
-            Message = message;
-            _onCommit = onCommit ?? EmptyCommitAction;
-        }
+    internal string Topic { get; set; }
 
-        internal string Topic { get; set; }
+    /// <summary>
+    /// The raw, unparsed message value as received from Kafka. Used when
+    /// forwarding a failed message to a dead letter queue.
+    /// </summary>
+    public string RawMessage { get; internal set; }
 
-        internal int Partition { get; set; }
+    internal int Partition { get; set; }
 
-        internal string PartitionKey { get; set; }
+    internal string PartitionKey { get; set; }
 
-        internal string ClientId { get; set; }
+    internal string ClientId { get; set; }
 
-        internal string GroupId { get; set; }
+    internal string GroupId { get; set; }
 
-        /// <summary>
-        /// Transmitted message consumed from Kafka
-        /// </summary>
-        public TransportLevelMessage Message { get; }
+    /// <summary>
+    /// Transmitted message consumed from Kafka
+    /// </summary>
+    public TransportLevelMessage Message { get; }
 
-        /// <summary>
-        /// Commit message to handlers
-        /// </summary>
-        public async Task Commit(CancellationToken cancellationToken)
-        {
-            await _onCommit(cancellationToken);
-        }
+    /// <summary>
+    /// Commit message to handlers
+    /// </summary>
+    public async Task Commit(CancellationToken cancellationToken)
+    {
+        await _onCommit(cancellationToken);
     }
 }

--- a/src/Dafda/Consuming/MessageResult.cs
+++ b/src/Dafda/Consuming/MessageResult.cs
@@ -14,7 +14,7 @@ public class MessageResult
     private readonly Func<CancellationToken, Task> _onCommit;
 
     /// <summary>
-    /// Resulting Message contaning Transport Level Message
+    /// Resulting Message containing Transport Level Message
     /// </summary>
     public MessageResult(TransportLevelMessage message, Func<CancellationToken, Task> onCommit = null)
     {

--- a/src/Dafda/Consuming/NullDeadLetterQueue.cs
+++ b/src/Dafda/Consuming/NullDeadLetterQueue.cs
@@ -1,0 +1,24 @@
+namespace Dafda.Consuming;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// A no-op <see cref="IDeadLetterQueue"/> used when no dead letter queue is
+/// configured. Its presence signals that failed messages should be rethrown
+/// (preserving the pre-existing behavior).
+/// </summary>
+internal sealed class NullDeadLetterQueue : IDeadLetterQueue
+{
+    public static readonly NullDeadLetterQueue Instance = new();
+
+    private NullDeadLetterQueue()
+    {
+    }
+
+    public Task Send(MessageResult message, Exception exception, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Pull request overview

This PR adds dead letter queue (DLQ) support to the Dafda Kafka consumer pipeline so failed messages (after optional retries) can be forwarded to a Kafka dead-letter topic and the consumer can commit the offset and continue.

## Why

Today a single "poison" message can take down or stall a consumer. When a message handler throws, the offset is never committed, so Dafda has only two outcomes:

- **The app crashes** — the exception escapes to `ConsumerHostedService`, and the default failure strategy calls `StopApplication()`. One bad message stops the whole service.
- **The consumer loops forever** — with `RestartConsumer`, the consumer restarts, re-reads from the *same uncommitted offset*, hits the same message, throws again… an infinite reprocessing loop that blocks every message behind it.

Neither is acceptable for a message that will never succeed (bad payload, unhandled edge case, downstream contract change). This PR adds a **dead letter queue** so poison messages are parked on a separate topic and the consumer moves on.

## Changes

- Introduces `IDeadLetterQueue` with a Kafka implementation (`KafkaDeadLetterQueue`) and a no-op default (`NullDeadLetterQueue`).
- Extends the consumption flow to **retry** handler dispatch a configurable number of times, then **publish the original message to the DLQ and commit** so processing continues.
- Adds fluent configuration — `WithDeadLetterQueue(...)` and `WithMaxRetries(...)` — plus unit tests for topic resolution and DLQ behavior.

## Usage

```csharp
services.AddConsumer(options =>
{
    options.WithGroupId("order-processor");
    options.WithBootstrapServers("localhost:9092");
    options.RegisterMessageHandler<OrderPlaced, OrderPlacedHandler>("orders", "order-placed");

    // Enable DLQ with up to 10 retries before dead-lettering
    options.WithDeadLetterQueue("orders.dead-letter").WithMaxRetries(10);
});
```

The topic name is optional. When omitted, it's derived per message as `"{topic}.{groupId}.dead-letter"` (e.g. `orders.order-processor.dead-letter`). Including the **consumer group** scopes the DLQ to the group that actually failed — important because a message that's poison for one consumer may be perfectly valid for another consuming the same topic.

## Behavior

```
GetNext → Dispatch ──success──────────────▶ Commit ─▶ next
              │
            throws
              │
      attempts < MaxRetries ? ──yes──▶ retry
              │ no
              ▼
   publish raw message + headers ─▶ dead-letter topic
              ▼
           Commit ─▶ next     (poison message parked, loop broken)
```

The dead-lettered record preserves the original key and raw payload, with diagnostics added as Kafka headers (source topic, exception type/message, timestamp).

## Design notes

- **Opt-in and fully backward compatible.** Without `WithDeadLetterQueue(...)`, the consumer uses `NullDeadLetterQueue` and exceptions propagate exactly as before. No existing option is affected.
- **Complements `WithConsumerErrorHandler`.** The DLQ absorbs per-message handler failures; genuinely catastrophic errors (connection loss, commit failures, and DLQ publish failures) still flow to the configured error handler.
- **Cancellation-safe.** Cancellation during dispatch is never retried or dead-lettered — it propagates for graceful shutdown.
- **No resource leaks.** `KafkaDeadLetterQueue` owns a producer and is disposed through the `ConsumerHostedService → Consumer` lifecycle on host shutdown.
- **Config isolation.** The DLQ producer is built from a filtered copy of the consumer settings (consumer-only keys removed), so it can't corrupt consumer configuration.

## Tests

Added coverage for retry-then-dead-letter, retry-then-succeed (no DLQ), propagation when DLQ is disabled, cancellation, disposal, and topic-name resolution (explicit, derived with group id, and group-less fallback).